### PR TITLE
Refactor Interpreter startup and default include paths.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,13 +356,24 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     )
 endif()
 
-add_definitions( -D_GNU_SOURCE
-  -DCLING_VERSION=${CLING_VERSION}
-  -DCLING_INCLUDE_PATHS="${CMAKE_INSTALL_PREFIX}/include:${CMAKE_CURRENT_SOURCE_DIR}/include:${CMAKE_CURRENT_SOURCE_DIR}/../clang/include:${CMAKE_CURRENT_SOURCE_DIR}/../../include" )
+add_definitions( -D_GNU_SOURCE -DCLING_VERSION=${CLING_VERSION})
 
 option(CLING_INCLUDE_TESTS
        "Generate build targets for the Cling unit tests."
        ${LLVM_INCLUDE_TESTS})
+
+#Allow user to prepend to list via cmake -DCLING_INCLUDE_PATHS=
+set(cling_include_deflt "\
+${CMAKE_INSTALL_PREFIX}/include:${CMAKE_CURRENT_SOURCE_DIR}/include:\
+${CMAKE_CURRENT_SOURCE_DIR}/../clang/include:\
+${CMAKE_CURRENT_SOURCE_DIR}/../../include"
+)
+
+if(NOT CLING_INCLUDE_PATHS)
+ set(CLING_INCLUDE_PATHS "${cling_include_deflt}")
+else()
+ set(CLING_INCLUDE_PATHS "${CLING_INCLUDE_PATHS}:${cling_include_deflt}")
+endif()
 
 # All targets below may depend on all tablegen'd files.
 get_property(CLANG_TABLEGEN_TARGETS GLOBAL PROPERTY CLANG_TABLEGEN_TARGETS)

--- a/Module.mk
+++ b/Module.mk
@@ -139,7 +139,7 @@ $(call stripsrc,$(CLINGDIR)/%.o): $(CLINGDIR)/%.cpp $(LLVMDEP)
 
 $(CLINGCOMPDH): FORCE $(LLVMDEP)
 	@mkdir -p $(dir $@)
-	@echo '#define LLVM_CXX "$(CXX) $(OPT) $(CLINGCXXFLAGSNOI)"' > $@_tmp
+	@echo '#define CLING_CXX_PATH "$(CXX) $(OPT) $(CLINGCXXFLAGSNOI)"' > $@_tmp
 	@diff -q $@_tmp $@ > /dev/null 2>&1 || mv $@_tmp $@
 	@rm -f $@_tmp
 

--- a/include/cling/Interpreter/CIFactory.h
+++ b/include/cling/Interpreter/CIFactory.h
@@ -24,19 +24,22 @@ namespace clang {
 }
 
 namespace cling {
+  class InvocationOptions;
+
   class CIFactory {
   public:
     typedef std::unique_ptr<llvm::MemoryBuffer> MemBufPtr_t;
-    // TODO: Add overload that takes file not MemoryBuffer
-    static clang::CompilerInstance* createCI(llvm::StringRef code,
-                                             int argc,
-                                             const char* const *argv,
-                                             const char* llvmdir);
 
-    static clang::CompilerInstance* createCI(MemBufPtr_t buffer,
-                                             int argc,
-                                             const char* const *argv,
-                                             const char* llvmdir,
+    // TODO: Add overload that takes file not MemoryBuffer
+
+    static clang::CompilerInstance* createCI(llvm::StringRef Code,
+                                             const InvocationOptions& Opts,
+                                             const char* LLVMDir);
+
+    static clang::CompilerInstance* createCI(MemBufPtr_t Buffer,
+                                             int Argc,
+                                             const char* const *Argv,
+                                             const char* LLVMDir,
                                              bool OnlyLex = false);
 
   private:

--- a/include/cling/Interpreter/CIFactory.h
+++ b/include/cling/Interpreter/CIFactory.h
@@ -26,28 +26,19 @@ namespace clang {
 namespace cling {
   class InvocationOptions;
 
-  class CIFactory {
-  public:
+  namespace CIFactory {
     typedef std::unique_ptr<llvm::MemoryBuffer> MemBufPtr_t;
 
     // TODO: Add overload that takes file not MemoryBuffer
 
-    static clang::CompilerInstance* createCI(llvm::StringRef Code,
-                                             const InvocationOptions& Opts,
-                                             const char* LLVMDir);
+    clang::CompilerInstance* createCI(llvm::StringRef Code,
+                                      const InvocationOptions& Opts,
+                                      const char* LLVMDir);
 
-    static clang::CompilerInstance* createCI(MemBufPtr_t Buffer,
-                                             int Argc,
-                                             const char* const *Argv,
-                                             const char* LLVMDir,
-                                             bool OnlyLex = false);
-
-  private:
-    //---------------------------------------------------------------------
-    //! Constructor
-    //---------------------------------------------------------------------
-    CIFactory() = delete;
-    ~CIFactory() = delete;
-  };
+    clang::CompilerInstance* createCI(MemBufPtr_t Buffer, int Argc,
+                                      const char* const *Argv,
+                                      const char* LLVMDir,
+                                      bool OnlyLex = false);
+  } // namespace CIFactory
 } // namespace cling
 #endif // CLING_CIFACTORY_H

--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -385,12 +385,15 @@ namespace cling {
     ///       a new include path region (e.g. "-cxx-isystem"). Also, flags
     ///       defining header search behavior will be included in incpaths, e.g.
     ///       "-nostdinc".
+    ///
     void GetIncludePaths(llvm::SmallVectorImpl<std::string>& incpaths,
                          bool withSystem, bool withFlags);
 
     ///\brief Prints the current include paths that are used.
     ///
-    void DumpIncludePath();
+    ///\param[in] S - stream to dump to or nullptr for default (llvm::outs)
+    ///
+    void DumpIncludePath(llvm::raw_ostream* S = nullptr);
 
     ///\brief Store the interpreter state in files
     /// Store the AST, the included files and the lookup tables

--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -268,10 +268,6 @@ namespace cling {
                                                 llvm::StringRef code,
                                                 bool withAccessControl);
 
-    ///\brief Set up include paths for runtime headers.
-    ///
-    void AddRuntimeIncludePaths(const char* argv0);
-
     ///\brief Include C++ runtime headers and definitions.
     ///
     void IncludeCXXRuntime();
@@ -370,9 +366,18 @@ namespace cling {
     ///
     bool isUniqueWrapper(llvm::StringRef name);
 
-    ///\brief Adds an include path (-I).
+    ///\brief Adds multiple include paths separated by a delimter.
     ///
-    void AddIncludePath(llvm::StringRef incpath);
+    ///\param[in] PathsStr - Path(s)
+    ///\param[in] Delim - Delimiter to separate paths or NULL if a single path
+    ///
+    void AddIncludePaths(llvm::StringRef PathsStr, const char* Delim = ":");
+
+    ///\brief Adds a single include path (-I).
+    ///
+    void AddIncludePath(llvm::StringRef PathsStr) {
+      return AddIncludePaths(PathsStr, nullptr);
+    }
 
     ///\brief Prints the current include paths that are used.
     ///

--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -14,16 +14,44 @@
 #include <vector>
 
 namespace cling {
+
+  ///\brief Class that stores options that are used by both cling and
+  /// clang::CompilerInvocation.
+  ///
+  class CompilerOptions {
+  public:
+    /// \brief Construct CompilerOptions from given arguments. When argc & argv
+    /// are 0, all arguments are saved into \pRemaining to pass to clang. If argc
+    /// or argv is 0, caller is must fill in \pRemaining with any arguments that
+    /// should be passed to clang.
+    ///
+    CompilerOptions(int argc = 0, const char* const *argv = nullptr);
+
+    ///\brief Parse argc, and argv into our variables.
+    ///
+    ///\param [in] argc - argument count
+    ///\param [in] argv - arguments
+    ///\param [out] Inputs - save all arguments that are inputs/files here
+    ///
+    void Parse(int argc, const char* const argv[],
+               std::vector<std::string>* Inputs = nullptr);
+
+    bool Language;
+    bool ResourceDir;
+    bool SysRoot;
+    bool NoBuiltinInc;
+    bool NoCXXInc;
+    bool StdVersion;
+    bool StdLib;
+
+    ///\brief The remaining arguments to pass to clang.
+    ///
+    std::vector<const char*> Remaining;
+  };
+
   class InvocationOptions {
   public:
-    InvocationOptions():
-      ErrorOut(false), NoLogo(false), ShowVersion(false), Verbose(false),
-      Help(false), MetaString(".") {}
-    bool ErrorOut;
-    bool NoLogo;
-    bool ShowVersion;
-    bool Verbose;
-    bool Help;
+    InvocationOptions(int argc, const char* const argv[]);
 
     /// \brief A line starting with this string is assumed to contain a
     ///        directive for the MetaProcessor. Defaults to "."
@@ -32,12 +60,15 @@ namespace cling {
     std::vector<std::string> LibsToLoad;
     std::vector<std::string> LibSearchPath;
     std::vector<std::string> Inputs;
+    CompilerOptions CompilerOpts;
 
-    static InvocationOptions CreateFromArgs(int argc, const char* const argv[],
-                                            std::vector<unsigned>& leftoverArgs
-                                            /* , Diagnostic &Diags */);
+    bool ErrorOut;
+    bool NoLogo;
+    bool ShowVersion;
+    bool Verbose;
+    bool Help;
 
-    void PrintHelp();
+    static void PrintHelp();
   };
 }
 

--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -43,6 +43,7 @@ namespace cling {
     bool NoCXXInc;
     bool StdVersion;
     bool StdLib;
+    bool Verbose;
 
     ///\brief The remaining arguments to pass to clang.
     ///
@@ -65,8 +66,8 @@ namespace cling {
     bool ErrorOut;
     bool NoLogo;
     bool ShowVersion;
-    bool Verbose;
     bool Help;
+    bool Verbose() const { return CompilerOpts.Verbose; }
 
     static void PrintHelp();
   };

--- a/include/cling/Utils/Paths.h
+++ b/include/cling/Utils/Paths.h
@@ -39,13 +39,15 @@ namespace cling {
     /// \param [out] Paths - All the paths in the string that exist
     /// \param [in] Mode - If any path doesn't exist stop and return false
     /// \param [in] Delim - The delimeter to use
+    /// \param [in] Verbose - Whether to print out details as 'clang -v' would
     ///
     /// \return true if all paths existed, otherwise false
     ///
     bool SplitPaths(llvm::StringRef PathStr,
                     llvm::SmallVectorImpl<llvm::StringRef>& Paths,
                     SplitMode Mode = kPruneNonExistant,
-                    llvm::StringRef Delim = llvm::StringRef(":"));
+                    llvm::StringRef Delim = llvm::StringRef(":"),
+                    bool Verbose = false);
 
     ///\brief Adds multiple include paths separated by a delimter into the
     /// given HeaderSearchOptions.  This adds the paths but does no further
@@ -59,6 +61,11 @@ namespace cling {
     void AddIncludePaths(llvm::StringRef PathStr,
                          clang::HeaderSearchOptions& Opts,
                          const char* Delim = ":");
+
+    ///\brief Write to llvm::errs that directory does not exist in a format
+    /// matching what 'clang -v' would do
+    ///
+    void LogNonExistantDirectory(llvm::StringRef Path);
 
     ///\brief Copies the current include paths into the HeaderSearchOptions.
     ///

--- a/include/cling/Utils/Paths.h
+++ b/include/cling/Utils/Paths.h
@@ -1,0 +1,37 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#ifndef CLING_UTILS_PATHS_H
+#define CLING_UTILS_PATHS_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace cling {
+  namespace utils {
+
+    ///\brief Collect the constituant paths from a PATH string.
+    /// /bin:/usr/bin:/usr/local/bin -> {/bin, /usr/bin, /usr/local/bin}
+    ///
+    /// All paths returned existed at the time of the call
+    /// \param [in] PathStr - The PATH string to be split
+    /// \param [out] Paths - All the paths in the string that exist
+    /// \param [in] EarlyOut - If any path doesn't exist stop and return false
+    /// \param [in] Delim - The delimeter to use
+    ///
+    /// \return true if all paths existed, otherwise false
+    ///
+    bool SplitPaths(llvm::StringRef PathStr,
+                    llvm::SmallVectorImpl<llvm::StringRef>& Paths,
+                    bool EarlyOut = false,
+                    llvm::StringRef Delim = llvm::StringRef(":"));
+  }
+}
+
+#endif // CLING_UTILS_PATHS_H

--- a/include/cling/Utils/Paths.h
+++ b/include/cling/Utils/Paths.h
@@ -12,6 +12,15 @@
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include <string>
+
+namespace llvm {
+  class raw_ostream;
+}
+
+namespace clang {
+  class HeaderSearchOptions;
+}
 
 namespace cling {
   namespace utils {
@@ -31,6 +40,37 @@ namespace cling {
                     llvm::SmallVectorImpl<llvm::StringRef>& Paths,
                     bool EarlyOut = false,
                     llvm::StringRef Delim = llvm::StringRef(":"));
+
+    ///\brief Copies the current include paths into the HeaderSearchOptions.
+    ///
+    ///\param[in] Opts - HeaderSearchOptions to read from
+    ///\param[out] Paths - Vector to output elements into
+    ///\param[in] WithSystem - if true, incpaths will also contain system
+    ///       include paths (framework, STL etc).
+    ///\param[in] WithFlags - if true, each element in incpaths will be prefixed
+    ///       with a "-I" or similar, and some entries of incpaths will signal
+    ///       a new include path region (e.g. "-cxx-isystem"). Also, flags
+    ///       defining header search behavior will be included in incpaths, e.g.
+    ///       "-nostdinc".
+    ///
+    void CopyIncludePaths(const clang::HeaderSearchOptions& Opts,
+                          llvm::SmallVectorImpl<std::string>& Paths,
+                          bool WithSystem, bool WithFlags);
+
+    ///\brief Prints the current include paths into the HeaderSearchOptions.
+    ///
+    ///\param[in] Opts - HeaderSearchOptions to read from
+    ///\param[in] Out - Stream to dump to
+    ///\param[in] WithSystem - dump contain system paths (framework, STL etc).
+    ///\param[in] WithFlags - if true, each line will be prefixed
+    ///       with a "-I" or similar, and some entries of incpaths will signal
+    ///       a new include path region (e.g. "-cxx-isystem"). Also, flags
+    ///       defining header search behavior will be included in incpaths, e.g.
+    ///       "-nostdinc".
+    ///
+    void DumpIncludePaths(const clang::HeaderSearchOptions& Opts,
+                          llvm::raw_ostream& Out,
+                          bool WithSystem, bool WithFlags);
   }
 }
 

--- a/include/cling/Utils/Paths.h
+++ b/include/cling/Utils/Paths.h
@@ -25,21 +25,40 @@ namespace clang {
 namespace cling {
   namespace utils {
 
+    enum SplitMode {
+      kPruneNonExistant,  ///< Don't add non-existant paths into output
+      kFailNonExistant,   ///< Fail on any non-existant paths
+      kAllowNonExistant   ///< Add all paths whether they exist or not
+    };
+
     ///\brief Collect the constituant paths from a PATH string.
     /// /bin:/usr/bin:/usr/local/bin -> {/bin, /usr/bin, /usr/local/bin}
     ///
     /// All paths returned existed at the time of the call
     /// \param [in] PathStr - The PATH string to be split
     /// \param [out] Paths - All the paths in the string that exist
-    /// \param [in] EarlyOut - If any path doesn't exist stop and return false
+    /// \param [in] Mode - If any path doesn't exist stop and return false
     /// \param [in] Delim - The delimeter to use
     ///
     /// \return true if all paths existed, otherwise false
     ///
     bool SplitPaths(llvm::StringRef PathStr,
                     llvm::SmallVectorImpl<llvm::StringRef>& Paths,
-                    bool EarlyOut = false,
+                    SplitMode Mode = kPruneNonExistant,
                     llvm::StringRef Delim = llvm::StringRef(":"));
+
+    ///\brief Adds multiple include paths separated by a delimter into the
+    /// given HeaderSearchOptions.  This adds the paths but does no further
+    /// processing. See Interpreter::AddIncludePaths or CIFactory::createCI
+    /// for examples of what needs to be done once the paths have been added.
+    ///
+    ///\param[in] PathsStr - Path(s)
+    ///\param[in] Opts - HeaderSearchOptions to add paths into
+    ///\param[in] Delim - Delimiter to separate paths or NULL if a single path
+    ///
+    void AddIncludePaths(llvm::StringRef PathStr,
+                         clang::HeaderSearchOptions& Opts,
+                         const char* Delim = ":");
 
     ///\brief Copies the current include paths into the HeaderSearchOptions.
     ///

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -1159,18 +1159,21 @@ namespace {
 
 } // unnamed namespace
 
-CompilerInstance* CIFactory::createCI(llvm::StringRef Code,
-                                      const InvocationOptions& Opts,
-                                      const char* LLVMDir) {
+namespace cling {
+namespace CIFactory {
+
+CompilerInstance* createCI(llvm::StringRef Code, const InvocationOptions& Opts,
+                           const char* LLVMDir) {
   return createCIImpl(llvm::MemoryBuffer::getMemBuffer(Code),
                       Opts.CompilerOpts, LLVMDir, false /*OnlyLex*/);
 }
 
-CompilerInstance* CIFactory::createCI(MemBufPtr_t Buffer,
-                                      int argc,
-                                      const char* const *argv,
-                                      const char* LLVMDir,
-                                      bool OnlyLex) {
+CompilerInstance* createCI(MemBufPtr_t Buffer, int argc, const char* const *argv,
+                           const char* LLVMDir, bool OnlyLex) {
   return createCIImpl(std::move(Buffer), CompilerOptions(argc, argv),
                       LLVMDir, OnlyLex);
 }
+
+}
+}
+

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 #include "cling/Interpreter/CIFactory.h"
+#include "cling/Utils/Paths.h"
 #include "ClingUtils.h"
 
 #include "DeclCollector.h"
@@ -588,27 +589,14 @@ namespace {
   }
 
   static bool AddCxxPaths(llvm::StringRef PathStr, AdditionalArgList& Args) {
-    bool Success = true;
-    llvm::SmallVector<llvm::StringRef, 6> Paths;
-    for (std::pair<llvm::StringRef, llvm::StringRef> Split
-           = PathStr.split(':');
-         !Split.second.empty(); Split = PathStr.split(':')) {
-      if (!llvm::sys::fs::is_directory(Split.first)) {
-        Success = false;
-        break;
-      }
-      Paths.push_back(Split.first);
-      PathStr = Split.second;
-    }
-    // Add remaining part
-    if (Success && llvm::sys::fs::is_directory(PathStr)) {
+      llvm::SmallVector<llvm::StringRef, 6> Paths;
+      if (!cling::utils::SplitPaths(PathStr, Paths, true))
+        return false;
+    
       for (llvm::StringRef Path : Paths)
         Args.addArgument("-I", Path.str());
-      Args.addArgument("-I", PathStr.str());
       return true;
     }
-    return false;
-  }
 
 #endif
   

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -710,14 +710,20 @@ namespace {
     // Only insert it if there is no other "-x":
     bool hasMinusX = false;
     const char* lang = "c++";
-    for (const char* const* iarg = argv; iarg < argv + argc; ++iarg) {
-      if (!strcmp(*iarg, "-Xclang")) {
-        ++iarg; // skip subsequent arg.
-        if (!strcmp(*iarg, "-x")) {
-          assert(iarg+2 < argv + argc && "Expected language after -Xclang -x");
-          lang = iarg[2]; // iarg[0]: -x, iarg[1]: -Xclang, iarg[2]: objc++
-        } else if (!strncmp(*iarg, "-x", 2)) {
-           lang = (*iarg) + 2;
+    for (const char* const* iarg = argv, * const* earg = argv + argc;
+         iarg < earg; ++iarg) {
+      if (!strncmp(*iarg, "-Xclang", 7) && (*iarg)[8] == 0) {
+        // goto next arg if there is one
+        if (++iarg < earg) {
+          if (!strncmp(*iarg, "-x", 2)) {
+            if ((*iarg)[2] == 0) {
+              // iarg[0]: -x, iarg[1]: -Xclang, iarg[2]: objc++
+              assert(iarg+2 < earg && "Expected language after -Xclang -x");
+              lang = iarg[2];
+            }
+            else
+              lang = (*iarg) + 2;
+          }
         }
         continue;
       }

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -292,5 +292,3 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
 
 add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
                       ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
-add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/Interpreter.cpp
-                      ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -108,27 +108,181 @@ endif()
 #add_dependencies(clangDriver ClangAttrList ClangDiagnosticDriver
 #                 ClangDriverOptions ClangCC1Options ClangCC1AsOptions)
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
-                   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in 
-                                                                 ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+if (UNIX)
 
-add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
-add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/Interpreter.cpp ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+  # Remove all -I from CMAKE_CXX_FLAGS
+  string(REPLACE ";" " " __flags "${CMAKE_CXX_FLAGS}")
+  string(REGEX REPLACE "-I[^ ]+" "" CLING_COMPILER_FLAGS_NO_I "${__flags}")
 
-# Remove all -I from CMAKE_CXX_FLAGS
-string(REPLACE ";" " " __flags "${CMAKE_CXX_FLAGS}")
-string(REGEX REPLACE "-I[^ ]+" "" CMAKE_CXX_FLAGS_NO_I "${__flags}")
+  option(CLING_CXX_PATH "Compiler cling will invoke for c++ headers." "")
+  option(CLING_CXX_HEADERS "Path cling will use for c++ headers." "")
 
-# Remove absolute path from CMAKE_CXX_COMPILER
-get_filename_component(_path ${CMAKE_CXX_COMPILER} PATH)
-get_filename_component(_name ${CMAKE_CXX_COMPILER} NAME)
-if("$ENV{PATH}" MATCHES ${_path})
-  set(CMAKE_CXX_COMPILER_RELATIVE ${_name})
-else()
-  set(CMAKE_CXX_COMPILER_RELATIVE ${CMAKE_CXX_COMPILER})
-endif()
+  function(stripNewLine strVal varName)
+    string(STRIP "${strVal}" strVal)
+    string(REGEX REPLACE "\\n$" "" strVal "${strVal}")
+    SET(${varName} ${strVal} PARENT_SCOPE)
+  endfunction()
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
-  "#define LLVM_CXX \"${CMAKE_CXX_COMPILER_RELATIVE} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
-"
-)
+  if(NOT CLING_CXX_PATH)
+    # Remove absolute path from CMAKE_CXX_COMPILER
+    get_filename_component(_name ${CMAKE_CXX_COMPILER} NAME)
+    get_filename_component(_path ${CMAKE_CXX_COMPILER} PATH)
+
+    # This should probably be more general...but how?
+    if(_name STREQUAL "ccache" OR _name STREQUAL "distcc")
+      separate_arguments(_arg_list UNIX_COMMAND "${CMAKE_CXX_COMPILER_ARG1}")
+      if (_arg_list)
+        list(GET _arg_list 0 _name)
+        string(STRIP "${_name}" _name)
+        if (APPLE)
+          execute_process(COMMAND xcrun -f ${_name}
+                          OUTPUT_VARIABLE CLING_CXX_FOUND
+                          OUTPUT_STRIP_TRAILING_WHITESPACE)
+          stripNewLine("${CLING_CXX_FOUND}" CLING_CXX_FOUND)
+        else()
+          find_program(_cling_cxx_path "${_name}")
+          execute_process(COMMAND ${_cling_cxx_path} -xc++ -E -v /dev/null
+                          OUTPUT_QUIET ERROR_VARIABLE _cling_cxx_path)
+
+          if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            execute_process(
+              COMMAND echo ${_cling_cxx_path}
+              COMMAND grep "COLLECT_GCC="
+              OUTPUT_VARIABLE _cling_cxx_path)
+              string(REPLACE "COLLECT_GCC=" "" _cling_cxx_path "${_cling_cxx_path}")
+
+          elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            execute_process(
+              COMMAND echo ${_cling_cxx_path}
+              COMMAND grep "/${_name}\" -cc1"
+              OUTPUT_VARIABLE _cling_clng_path)
+
+            if(NOT _cling_clng_path)
+              execute_process(
+                COMMAND echo ${_cling_cxx_path}
+                COMMAND grep "/clang\" -cc1"
+                OUTPUT_VARIABLE _cling_clng_path)
+            endif()
+
+            separate_arguments(_arg_list UNIX_COMMAND "${_cling_clng_path}")
+            if (_arg_list)
+              list(GET _arg_list 0 _cling_cxx_path)
+            endif()
+          endif()
+
+          stripNewLine("${_cling_cxx_path}" _cling_cxx_path)
+          set(CLING_CXX_FOUND "${_cling_cxx_path}")
+        endif()
+
+        if (NOT EXISTS "${CLING_CXX_FOUND}")
+          find_program(CLING_CXX_FOUND "${_name}")
+        endif()
+      else()
+        set(CLING_CXX_FOUND "")
+        set(_name "")
+      endif()
+
+      if (EXISTS ${CLING_CXX_FOUND})
+        set(CLING_CXX_PATH ${CLING_CXX_FOUND})
+        get_filename_component(_name ${CLING_CXX_PATH} NAME)
+        get_filename_component(_path ${CLING_CXX_PATH} PATH)
+      else()
+        set(CLING_CXX_PATH "${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1}")
+        if(_name)
+          set(CLING_CXX_RLTV "${_name}")
+        endif()
+        set(_path "__THISREALLYBETTERNOTBEINPATH_THANKS__")
+      endif()
+    else()
+      get_filename_component(_path ${CMAKE_CXX_COMPILER} PATH)
+    endif()
+
+    if("$ENV{PATH}" MATCHES ${_path})
+      set(CLING_CXX_RLTV ${_name})
+    elseif(NOT CLING_CXX_PATH)
+      set(CLING_CXX_PATH ${CMAKE_CXX_COMPILER})
+    endif()
+  endif()
+
+  if(NOT CLING_CXX_HEADERS)
+    if (CLING_CXX_PATH)
+      execute_process(COMMAND ${CLING_CXX_PATH} -xc++ -E -v /dev/null
+                      OUTPUT_QUIET ERROR_VARIABLE CLING_CXX_HEADERS)
+    else()
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} -xc++ -E -v /dev/null
+                      OUTPUT_QUIET ERROR_VARIABLE CLING_CXX_HEADERS)
+    endif()
+
+    execute_process(
+      COMMAND echo ${CLING_CXX_HEADERS}
+      COMMAND awk "/^#include </,/^End of search/{if (!/^#include </ && !/^End of search/){ print }}"
+      COMMAND grep -E "(c|g)\\+\\+"
+      OUTPUT_VARIABLE CLING_CXX_HEADERS)
+
+    stripNewLine("${CLING_CXX_HEADERS}" CLING_CXX_HEADERS)
+  endif()
+
+  if (NOT EXISTS ${CLING_CXX_HEADERS})
+    string(REPLACE "\n" ";" _cxx_inc_paths ${CLING_CXX_HEADERS})
+    foreach(_cxx_inc_path ${_cxx_inc_paths})
+      string(STRIP "${_cxx_inc_path}" _cxx_inc_path)
+      if (NOT EXISTS ${_cxx_inc_path})
+        set(_cxx_inc_join "")
+        break()
+      endif()
+      if(_cxx_inc_join)
+        set(_cxx_inc_join "${_cxx_inc_join}:${_cxx_inc_path}")
+      else()
+        set(_cxx_inc_join "${_cxx_inc_path}")
+      endif()
+    endforeach()
+    set(CLING_CXX_HEADERS "${_cxx_inc_join}")
+    if (NOT CLING_CXX_HEADERS)
+      MESSAGE(WARNING "Cannot determine location of C++ headers for runtime.")
+    endif()
+  endif()
+
+  MESSAGE(STATUS "Cling will look for C++ headers in '${CLING_CXX_HEADERS}' at runtime.")
+
+  if (CLING_CXX_PATH)
+    MESSAGE(STATUS "And if not found, will invoke: '${CLING_CXX_PATH}' for them.")
+    if (CLING_CXX_RLTV)
+      MESSAGE(STATUS "And then fallback to: '${CLING_CXX_RLTV}'")
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+        "
+        #define CLING_CXX_INCL \"${CLING_CXX_HEADERS}\"
+        #define CLING_CXX_PATH \"${CLING_CXX_PATH} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
+        #define CLING_CXX_RLTV \"${CLING_CXX_RLTV} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
+      ")
+    else()
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+        "
+        #define CLING_CXX_INCL \"${CLING_CXX_HEADERS}\"
+        #define CLING_CXX_PATH \"${CLING_CXX_PATH} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
+      ")
+    endif()
+  else()
+    MESSAGE(STATUS "And if not found, will invoke: '${CLING_CXX_RLTV}' for them.")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+      "
+      #define CLING_CXX_INCL \"${CLING_CXX_HEADERS}\"
+      #define CLING_CXX_RLTV \"${CLING_CXX_RLTV} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
+    ")
+  endif()
+
+  # Make sure this goes last so so we can pick up any changes that occured
+  # Also means cling-compiledata.h.in should be edited never cling-compiledata.h
+
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
+                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                     ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+                     ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
+                     MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+                     COMMENT "Updating cling-compiledata.h")
+
+  add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
+                        ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+  add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/Interpreter.cpp
+                        ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+
+endif() # UNIX

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -253,12 +253,14 @@ if (UNIX)
         #define CLING_CXX_INCL \"${CLING_CXX_HEADERS}\"
         #define CLING_CXX_PATH \"${CLING_CXX_PATH} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
         #define CLING_CXX_RLTV \"${CLING_CXX_RLTV} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
+        #define CLING_INCLUDE_PATHS \"${CLING_INCLUDE_PATHS}\"
       ")
     else()
       file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
         "
         #define CLING_CXX_INCL \"${CLING_CXX_HEADERS}\"
         #define CLING_CXX_PATH \"${CLING_CXX_PATH} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
+        #define CLING_INCLUDE_PATHS \"${CLING_INCLUDE_PATHS}\"
       ")
     endif()
   else()
@@ -267,22 +269,28 @@ if (UNIX)
       "
       #define CLING_CXX_INCL \"${CLING_CXX_HEADERS}\"
       #define CLING_CXX_RLTV \"${CLING_CXX_RLTV} ${CMAKE_CXX_FLAGS_NO_I} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}}\"
+      #define CLING_INCLUDE_PATHS \"${CLING_INCLUDE_PATHS}\"
     ")
   endif()
 
-  # Make sure this goes last so so we can pick up any changes that occured
-  # Also means cling-compiledata.h.in should be edited never cling-compiledata.h
+else()
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+      "
+      #define CLING_INCLUDE_PATHS \"${CLING_INCLUDE_PATHS}\"
+    ")
+endif()
 
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
-                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                     ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
-                     ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
-                     MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
-                     COMMENT "Updating cling-compiledata.h")
+# Make sure this goes last so so we can pick up any changes that occured
+# Also means cling-compiledata.h.in should be edited never cling-compiledata.h
 
-  add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
-                        ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
-  add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/Interpreter.cpp
-                        ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
+                   COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                   ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h
+                   MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h.in
+                   COMMENT "Updating cling-compiledata.h")
 
-endif() # UNIX
+add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/CIFactory.cpp
+                      ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)
+add_file_dependencies(${CMAKE_CURRENT_SOURCE_DIR}/Interpreter.cpp
+                      ${CMAKE_CURRENT_BINARY_DIR}/cling-compiledata.h)

--- a/lib/Interpreter/IncrementalParser.cpp
+++ b/lib/Interpreter/IncrementalParser.cpp
@@ -82,7 +82,7 @@ namespace {
 # define CLING_CXXABIV -1 // intentionally invalid macro name
 # define CLING_CXXABIS "-1" // intentionally invalid macro name
     llvm::errs()
-      << "Warning in cling::CIFactory::createCI():\n  "
+      << "Warning in cling::IncrementalParser::CheckABICompatibility():\n  "
       "C++ ABI check not implemented for this standard library\n";
     return;
 #endif
@@ -100,7 +100,7 @@ namespace {
     }
     else {
       llvm::errs()
-        << "Warning in cling::CIFactory::createCI():\n  "
+        << "Warning in cling::IncrementalParser::CheckABICompatibility():\n  "
         "Possible C++ standard library mismatch, compiled with Visual Studio v"
         << VSVersion << ".0,\n"
         "but this version of Visual Studio was not found in your system's registry.\n";

--- a/lib/Interpreter/IncrementalParser.h
+++ b/lib/Interpreter/IncrementalParser.h
@@ -36,7 +36,6 @@ namespace clang {
 namespace cling {
   class BackendPasses;
   class CompilationOptions;
-  class CIFactory;
   class DeclCollector;
   class ExecutionContext;
   class Interpreter;

--- a/lib/Interpreter/IncrementalParser.h
+++ b/lib/Interpreter/IncrementalParser.h
@@ -101,8 +101,7 @@ namespace cling {
     };
     typedef llvm::PointerIntPair<Transaction*, 2, EParseResult>
       ParseResultTransaction;
-    IncrementalParser(Interpreter* interp, int argc, const char* const *argv,
-                      const char* llvmdir, bool isChildInterpreter);
+    IncrementalParser(Interpreter* interp, const char* llvmdir);
     ~IncrementalParser();
 
     void Initialize(llvm::SmallVectorImpl<ParseResultTransaction>& result,

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -211,7 +211,9 @@ namespace cling {
 
     handleFrontendOptions();
 
-    AddRuntimeIncludePaths(argv[0]);
+    // -nobuiltininc
+    if (getCI()->getHeaderSearchOpts().UseBuiltinIncludes)
+      AddRuntimeIncludePaths(argv[0]);
 
     if (!noRuntime) {
       if (getCI()->getLangOpts().CPlusPlus)

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -10,7 +10,6 @@
 #include "cling/Interpreter/Interpreter.h"
 #include "ClingUtils.h"
 
-#include "cling-compiledata.h"
 #include "DynamicLookup.h"
 #include "ExternalInterpreterSource.h"
 #include "ForwardDeclPrinter.h"

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -8,8 +8,10 @@
 //------------------------------------------------------------------------------
 
 #include "cling/Interpreter/Interpreter.h"
+#include "cling/Utils/Paths.h"
 #include "ClingUtils.h"
 
+#include "cling-compiledata.h"
 #include "DynamicLookup.h"
 #include "ExternalInterpreterSource.h"
 #include "ForwardDeclPrinter.h"
@@ -298,16 +300,10 @@ namespace cling {
   void Interpreter::AddRuntimeIncludePaths(const char* argv0) {
     // Add configuration paths to interpreter's include files.
 #ifdef CLING_INCLUDE_PATHS
-    llvm::StringRef InclPaths(CLING_INCLUDE_PATHS);
-    for (std::pair<llvm::StringRef, llvm::StringRef> Split
-           = InclPaths.split(':');
-         !Split.second.empty(); Split = InclPaths.split(':')) {
-      if (llvm::sys::fs::is_directory(Split.first))
-        AddIncludePath(Split.first);
-      InclPaths = Split.second;
-    }
-    // Add remaining part
-    AddIncludePath(InclPaths);
+      llvm::SmallVector<llvm::StringRef, 6> Paths;
+      utils::SplitPaths(CLING_INCLUDE_PATHS, Paths);
+      for (llvm::StringRef Path : Paths)
+        AddIncludePath(Path);
 #endif
     llvm::SmallString<512> P(GetExecutablePath(argv0));
     if (!P.empty()
@@ -323,7 +319,6 @@ namespace cling {
       if (llvm::sys::fs::is_directory(P.str()))
         AddIncludePath(P.str());
     }
-
   }
 
   void Interpreter::IncludeCXXRuntime() {

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -158,23 +158,13 @@ namespace cling {
   Interpreter::Interpreter(int argc, const char* const *argv,
                            const char* llvmdir /*= 0*/, bool noRuntime,
                            bool isChildInterp) :
-    m_UniqueCounter(0), m_PrintDebug(false), m_DynamicLookupDeclared(false),
-    m_DynamicLookupEnabled(false), m_RawInputEnabled(false) {
+    m_Opts(argc, argv), m_UniqueCounter(0), m_PrintDebug(false),
+    m_DynamicLookupDeclared(false), m_DynamicLookupEnabled(false),
+    m_RawInputEnabled(false) {
 
     m_LLVMContext.reset(new llvm::LLVMContext);
-    std::vector<unsigned> LeftoverArgsIdx;
-    m_Opts = InvocationOptions::CreateFromArgs(argc, argv, LeftoverArgsIdx);
-    std::vector<const char*> LeftoverArgs;
-
-    for (size_t I = 0, N = LeftoverArgsIdx.size(); I < N; ++I) {
-      LeftoverArgs.push_back(argv[LeftoverArgsIdx[I]]);
-    }
-
     m_DyLibManager.reset(new DynamicLibraryManager(getOptions()));
-
-    m_IncrParser.reset(new IncrementalParser(this, LeftoverArgs.size(),
-                                             &LeftoverArgs[0],
-                                             llvmdir, isChildInterp));
+    m_IncrParser.reset(new IncrementalParser(this, llvmdir));
 
     Sema& SemaRef = getSema();
     Preprocessor& PP = SemaRef.getPreprocessor();

--- a/lib/Interpreter/InvocationOptions.cpp
+++ b/lib/Interpreter/InvocationOptions.cpp
@@ -65,7 +65,6 @@ namespace {
     Opts.ErrorOut = Args.hasArg(OPT__errorout);
     Opts.NoLogo = Args.hasArg(OPT__nologo);
     Opts.ShowVersion = Args.hasArg(OPT_version);
-    Opts.Verbose = Args.hasArg(OPT_v);
     Opts.Help = Args.hasArg(OPT_help);
     if (Args.hasArg(OPT__metastr, OPT__metastr_EQ)) {
       Arg* MetaStringArg = Args.getLastArg(OPT__metastr, OPT__metastr_EQ);
@@ -92,7 +91,7 @@ namespace {
 
 CompilerOptions::CompilerOptions(int argc, const char* const* argv) :
   Language(false), ResourceDir(false), SysRoot(false), NoBuiltinInc(false),
-  NoCXXInc(false), StdVersion(false), StdLib(false) {
+  NoCXXInc(false), StdVersion(false), StdLib(false), Verbose(false) {
   if (argc && argv) {
     // Preserve what's already in Remaining, the user might want to push args
     // to clang while still using main's argc, argv
@@ -127,6 +126,7 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
       case options::OPT_nobuiltininc: NoBuiltinInc = true; break;
       // case options::OPT_nostdinc:
       case options::OPT_nostdincxx: NoCXXInc = true; break;
+      case options::OPT_v: Verbose = true; break;
 
       default:
         if (Inputs && arg->getOption().getKind() == Option::InputClass)
@@ -138,7 +138,7 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
 
 InvocationOptions::InvocationOptions(int argc, const char* const* argv) :
   MetaString("."), ErrorOut(false), NoLogo(false), ShowVersion(false),
-  Verbose(false), Help(false) {
+  Help(false) {
 
   ArrayRef<const char *> ArgStrings(argv, argv + argc);
   unsigned MissingArgIndex, MissingArgCount;
@@ -151,6 +151,10 @@ InvocationOptions::InvocationOptions(int argc, const char* const* argv) :
   // Forward unknown arguments.
   for (const Arg* arg : Args) {
     switch (arg->getOption().getKind()) {
+      case Option::FlagClass:
+        // pass -v to clang as well
+        if (arg->getOption().getID() != OPT_v)
+          break;
       case Option::UnknownClass:
       case Option::InputClass:
         // prune "-" we need to control where it appears when invoking clang

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -11,6 +11,7 @@ set( LLVM_LINK_COMPONENTS
 
 add_cling_library(clingUtils OBJECT
   AST.cpp
+  Paths.cpp
   SourceNormalization.cpp
   Validation.cpp
 

--- a/lib/Utils/Paths.cpp
+++ b/lib/Utils/Paths.cpp
@@ -1,0 +1,41 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author:
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#include "cling/Utils/Paths.h"
+#include "llvm/Support/FileSystem.h"
+
+namespace cling {
+namespace utils {
+
+bool SplitPaths(llvm::StringRef PathStr,
+                llvm::SmallVectorImpl<llvm::StringRef>& Paths, bool EarlyOut,
+                llvm::StringRef Delim) {
+  bool AllExisted = true;
+  for (std::pair<llvm::StringRef, llvm::StringRef> Split = PathStr.split(Delim);
+       !Split.second.empty(); Split = PathStr.split(Delim)) {
+    if (!llvm::sys::fs::is_directory(Split.first)) {
+      if (EarlyOut)
+        return false;
+      AllExisted = false;
+    } else
+      Paths.push_back(Split.first);
+    PathStr = Split.second;
+  }
+
+  // Add remaining part
+  if (llvm::sys::fs::is_directory(PathStr))
+    Paths.push_back(PathStr);
+  else
+    AllExisted = false;
+
+  return AllExisted;
+}
+
+} // namespace utils
+} // namespace cling

--- a/lib/Utils/Paths.cpp
+++ b/lib/Utils/Paths.cpp
@@ -8,10 +8,111 @@
 //------------------------------------------------------------------------------
 
 #include "cling/Utils/Paths.h"
+#include "clang/Lex/HeaderSearchOptions.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace cling {
 namespace utils {
+
+using namespace clang;
+
+// Adapted from clang/lib/Frontend/CompilerInvocation.cpp
+
+void CopyIncludePaths(const clang::HeaderSearchOptions& Opts,
+                      llvm::SmallVectorImpl<std::string>& incpaths,
+                      bool withSystem, bool withFlags) {
+  if (withFlags && Opts.Sysroot != "/") {
+    incpaths.push_back("-isysroot");
+    incpaths.push_back(Opts.Sysroot);
+  }
+
+  /// User specified include entries.
+  for (unsigned i = 0, e = Opts.UserEntries.size(); i != e; ++i) {
+    const HeaderSearchOptions::Entry &E = Opts.UserEntries[i];
+    if (E.IsFramework && E.Group != frontend::Angled)
+      llvm::report_fatal_error("Invalid option set!");
+    switch (E.Group) {
+    case frontend::After:
+      if (withFlags) incpaths.push_back("-idirafter");
+      break;
+
+    case frontend::Quoted:
+      if (withFlags) incpaths.push_back("-iquote");
+      break;
+
+    case frontend::System:
+      if (!withSystem) continue;
+      if (withFlags) incpaths.push_back("-isystem");
+      break;
+
+    case frontend::IndexHeaderMap:
+      if (!withSystem) continue;
+      if (withFlags) incpaths.push_back("-index-header-map");
+      if (withFlags) incpaths.push_back(E.IsFramework? "-F" : "-I");
+      break;
+
+    case frontend::CSystem:
+      if (!withSystem) continue;
+      if (withFlags) incpaths.push_back("-c-isystem");
+      break;
+
+    case frontend::ExternCSystem:
+      if (!withSystem) continue;
+      if (withFlags) incpaths.push_back("-extern-c-isystem");
+      break;
+
+    case frontend::CXXSystem:
+      if (!withSystem) continue;
+      if (withFlags) incpaths.push_back("-cxx-isystem");
+      break;
+
+    case frontend::ObjCSystem:
+      if (!withSystem) continue;
+      if (withFlags) incpaths.push_back("-objc-isystem");
+      break;
+
+    case frontend::ObjCXXSystem:
+      if (!withSystem) continue;
+      if (withFlags) incpaths.push_back("-objcxx-isystem");
+      break;
+
+    case frontend::Angled:
+      if (withFlags) incpaths.push_back(E.IsFramework ? "-F" : "-I");
+      break;
+    }
+    incpaths.push_back(E.Path);
+  }
+
+  if (withSystem && !Opts.ResourceDir.empty()) {
+    if (withFlags) incpaths.push_back("-resource-dir");
+    incpaths.push_back(Opts.ResourceDir);
+  }
+  if (withSystem && withFlags && !Opts.ModuleCachePath.empty()) {
+    incpaths.push_back("-fmodule-cache-path");
+    incpaths.push_back(Opts.ModuleCachePath);
+  }
+  if (withSystem && withFlags && !Opts.UseStandardSystemIncludes)
+    incpaths.push_back("-nostdinc");
+  if (withSystem && withFlags && !Opts.UseStandardCXXIncludes)
+    incpaths.push_back("-nostdinc++");
+  if (withSystem && withFlags && Opts.UseLibcxx)
+    incpaths.push_back("-stdlib=libc++");
+  if (withSystem && withFlags && Opts.Verbose)
+    incpaths.push_back("-v");
+}
+
+void DumpIncludePaths(const clang::HeaderSearchOptions& Opts,
+                      llvm::raw_ostream& Out,
+                      bool WithSystem, bool WithFlags) {
+  llvm::SmallVector<std::string, 100> IncPaths;
+  CopyIncludePaths(Opts, IncPaths, WithSystem, WithFlags);
+  // print'em all
+  for (unsigned i = 0; i < IncPaths.size(); ++i) {
+    Out << IncPaths[i] <<"\n";
+  }
+}
 
 bool SplitPaths(llvm::StringRef PathStr,
                 llvm::SmallVectorImpl<llvm::StringRef>& Paths, bool EarlyOut,
@@ -36,6 +137,6 @@ bool SplitPaths(llvm::StringRef PathStr,
 
   return AllExisted;
 }
-
+  
 } // namespace utils
 } // namespace cling

--- a/test/Driver/NoStdInc.C
+++ b/test/Driver/NoStdInc.C
@@ -1,0 +1,22 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// This test is dependent on IncrementalParser::Initialize
+// calling ParseInternal("#include <new>");
+// and the structure of the warning message 
+// It will also fail when it is not possible to verify matching C++ ABIs
+
+// RUN: cat %s | %cling -nostdinc++ -Xclang -verify 2>&1 | FileCheck %s
+// Test nobuiltinincTest
+
+// expected-error@1 {{'new' file not found}}
+
+// CHECK: Warning in cling::IncrementalParser::CheckABICompatibility():
+// CHECK:  Possible C++ standard library mismatch, compiled with {{.*$}}
+
+.q

--- a/test/Interfaces/Paths/A/A.h
+++ b/test/Interfaces/Paths/A/A.h
@@ -1,0 +1,1 @@
+const char* TestA = "TestA";

--- a/test/Interfaces/Paths/B/B.h
+++ b/test/Interfaces/Paths/B/B.h
@@ -1,0 +1,1 @@
+const char* TestB = "TestB";

--- a/test/Interfaces/Paths/C/C.h
+++ b/test/Interfaces/Paths/C/C.h
@@ -1,0 +1,1 @@
+const char* TestC = "TestC";

--- a/test/Interfaces/Paths/D/D.h
+++ b/test/Interfaces/Paths/D/D.h
@@ -1,0 +1,1 @@
+const char* TestD = "TestD";

--- a/test/Interfaces/invocationFlags.C
+++ b/test/Interfaces/invocationFlags.C
@@ -1,0 +1,64 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %built_cling -Xclang -verify | FileCheck %s
+// Make sure we are correctly parsing the arguments for CIFactory::createCI
+
+#include "cling/Interpreter/InvocationOptions.h"
+
+const char* argv[] = {
+  "progname",
+  "-",
+  "-xobjective-c",
+  "FileToExecuteA",
+  "-isysroot",
+  "APAth",
+  "-v",
+  "FileToExecuteB",
+  "-L/Path/To/Libs",
+  "-lTest"
+};
+const int argc = sizeof(argv)/sizeof(argv[0]);
+
+cling::CompilerOptions COpts(argc, argv);
+
+COpts.Language
+// CHECK: (bool) true
+COpts.SysRoot
+// CHECK: (bool) true
+COpts.NoCXXInc
+// CHECK: (bool) false
+
+// library caller options: arguments passed as is
+COpts.Remaining
+// CHECK: {{.*}} { "progname", "-", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", "-v", "FileToExecuteB", "-L/Path/To/Libs", "-lTest" }
+
+argv[6] = "-nostdinc++";
+cling::InvocationOptions IOpts(argc, argv);
+IOpts.Inputs
+// CHECK: {{.*}} { "-", "FileToExecuteA", "FileToExecuteB" }
+
+IOpts.LibSearchPath
+// CHECK: {{.*}} { "/Path/To/Libs" }
+
+IOpts.LibsToLoad
+// CHECK: {{.*}} { "Test" }
+
+IOpts.CompilerOpts.Language
+// CHECK: (bool) true
+IOpts.CompilerOpts.SysRoot
+// CHECK: (bool) true
+IOpts.CompilerOpts.NoCXXInc
+// CHECK: (bool) true
+
+// user options from main: filtered by cling (no '-')
+IOpts.CompilerOpts.Remaining
+// CHECK: {{.*}} { "progname", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", "-nostdinc++", "FileToExecuteB" }
+
+// expected-no-diagnostics
+.q

--- a/test/Interfaces/invocationFlags.C
+++ b/test/Interfaces/invocationFlags.C
@@ -18,6 +18,7 @@ const char* argv[] = {
   "FileToExecuteA",
   "-isysroot",
   "APAth",
+  "-nobuiltininc",
   "-v",
   "FileToExecuteB",
   "-L/Path/To/Libs",
@@ -31,12 +32,14 @@ COpts.Language
 // CHECK: (bool) true
 COpts.SysRoot
 // CHECK: (bool) true
+COpts.NoBuiltinInc
+// CHECK: (bool) true
 COpts.NoCXXInc
 // CHECK: (bool) false
 
 // library caller options: arguments passed as is
 COpts.Remaining
-// CHECK: {{.*}} { "progname", "-", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", "-v", "FileToExecuteB", "-L/Path/To/Libs", "-lTest" }
+// CHECK: {{.*}} { "progname", "-", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", "-nobuiltininc", "-v", "FileToExecuteB", "-L/Path/To/Libs", "-lTest" }
 
 argv[6] = "-nostdinc++";
 cling::InvocationOptions IOpts(argc, argv);
@@ -53,12 +56,14 @@ IOpts.CompilerOpts.Language
 // CHECK: (bool) true
 IOpts.CompilerOpts.SysRoot
 // CHECK: (bool) true
+IOpts.CompilerOpts.NoBuiltinInc
+// CHECK: (bool) false
 IOpts.CompilerOpts.NoCXXInc
 // CHECK: (bool) true
 
 // user options from main: filtered by cling (no '-')
 IOpts.CompilerOpts.Remaining
-// CHECK: {{.*}} { "progname", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", "-nostdinc++", "FileToExecuteB" }
+// CHECK: {{.*}} { "progname", "-xobjective-c", "FileToExecuteA", "-isysroot", "APAth", "-nostdinc++", "-v", "FileToExecuteB" }
 
 // expected-no-diagnostics
 .q

--- a/test/Interfaces/paths.C
+++ b/test/Interfaces/paths.C
@@ -1,0 +1,32 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -DTEST_PATH=\"%p/\" -Xclang -verify 2>&1 | FileCheck %s
+
+#include "cling/Interpreter/Interpreter.h"
+
+gCling->AddIncludePaths(TEST_PATH "Paths/A:" TEST_PATH "Paths/B:"
+                        TEST_PATH "Paths/C");
+#include "A.h"
+#include "B.h"
+#include "C.h"
+
+gCling->AddIncludePath(TEST_PATH "Paths/D");
+#include "D.h"
+
+TestA
+// CHECK: (const char *) "TestA"
+TestB
+// CHECK: (const char *) "TestB"
+TestC
+// CHECK: (const char *) "TestC"
+TestD
+// CHECK: (const char *) "TestD"
+
+// expected-no-diagnostics
+.q


### PR DESCRIPTION
This is the first step in getting clang & cling to run from the same installation.