### PR TITLE
Match exception specification for InterpreterException.

### DIFF
--- a/include/cling/Interpreter/Exception.h
+++ b/include/cling/Interpreter/Exception.h
@@ -42,7 +42,7 @@ namespace cling {
     DerefType m_Type;
   public:
     InvalidDerefException(clang::Sema* S, clang::Expr* E, DerefType type);
-    virtual ~InvalidDerefException();
+    virtual ~InvalidDerefException() noexcept;
 
     const char* what() const noexcept override;
     void diagnose() const override;

--- a/include/cling/UserInterface/CompilationException.h
+++ b/include/cling/UserInterface/CompilationException.h
@@ -32,7 +32,7 @@ namespace cling {
   public:
     CompilationException(const std::string& reason):
       std::runtime_error(reason) {}
-    ~CompilationException() throw(); // vtable pinned to UserInterface.cpp
+    ~CompilationException() noexcept; // vtable pinned to UserInterface.cpp
     virtual const char* what() const throw() {
       return std::runtime_error::what(); }
   };

--- a/lib/Interpreter/ExceptionRTTI.cpp
+++ b/lib/Interpreter/ExceptionRTTI.cpp
@@ -59,7 +59,7 @@ namespace cling {
     return "runtime_exception\n";
   }
 
-  InvalidDerefException::~InvalidDerefException() {}
+  InvalidDerefException::~InvalidDerefException() noexcept {}
 
   const char* InvalidDerefException::what() const noexcept {
     // Invalid memory access.

--- a/lib/UserInterface/UserInterface.cpp
+++ b/lib/UserInterface/UserInterface.cpp
@@ -111,7 +111,7 @@ namespace {
 
 namespace cling {
   // Declared in CompilationException.h; vtable pinned here.
-  CompilationException::~CompilationException() throw() {}
+  CompilationException::~CompilationException() noexcept {}
 
   UserInterface::UserInterface(Interpreter& interp) {
     // We need stream that doesn't close its file descriptor, thus we are not


### PR DESCRIPTION
Some compilers are complaining about the mismatching exception specifications
between destructors of InterpreterException and its subclasses.