### PR TITLE
Fix missing call to pclose, introduced in 877a1f4.

### DIFF
--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -378,12 +378,13 @@ static bool getISysRootVersion(const std::string& SDKs, int Major,
 }
 
 static std::string ReadSingleLine(const char* Cmd) {
-
-  if (FILE *PF = ::popen(Cmd, "r")) {
+  if (FILE* PF = ::popen(Cmd, "r")) {
     char Buf[1024];
-    if (fgets(Buf, sizeof(Buf), PF)) {
+    char* BufPtr = ::fgets(Buf, sizeof(Buf), PF);
+    ::pclose(PF);
+    if (BufPtr && Buf[0]) {
       const llvm::StringRef Result(Buf);
-      assert(Result.size() < sizeof(Buf) && "Single line too large");
+      assert(Result[Result.size()-1] == '\n' && "Single line too large");
       return Result.trim().str();
     }
   }


### PR DESCRIPTION
Sorry, would have been nice to squash this, but it was hiding further up the tree than I was looking.
At least conflicts are useful sometimes!