### PR TITLE
Move DeclUnloader and ParserStateRAII into cling namespace.

### DIFF
--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -23,9 +23,8 @@
 
 #include "llvm/IR/Constants.h"
 
-// FIXME: rename back to cling when gcc fix the
-// namespace cling { using cling::DeclUnloader DeclUnloader} bug
-namespace clang {
+namespace cling {
+using namespace clang;
 
 bool DeclUnloader::isDefinition(TagDecl* R) {
   return R->isCompleteDefinition() && isa<CXXRecordDecl>(R);
@@ -173,8 +172,6 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
 #endif
   return true;
 }
-
- using namespace cling;
 
   // Copied and adapted from GlobalDCE.cpp
   class GlobalValueEraser {
@@ -964,4 +961,4 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
                                                  CanonCTSD);
     return Successful;
   }
-} // end namespace clang
+} // end namespace cling

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -14,23 +14,24 @@
 
 #include "clang/AST/DeclVisitor.h"
 
-namespace clang {
 
+namespace clang {
   class CodeGenerator;
   class GlobalDecl;
+}
 
-  using cling::Transaction;
+namespace cling {
 
   ///\brief The class does the actual work of removing a declaration and
   /// resetting the internal structures of the compiler
   ///
-  class DeclUnloader : public DeclVisitor<DeclUnloader, bool> {
+  class DeclUnloader : public clang::DeclVisitor<cling::DeclUnloader, bool> {
   private:
-    typedef llvm::DenseSet<FileID> FileIDs;
+    typedef llvm::DenseSet<clang::FileID> FileIDs;
 
     ///\brief The Sema object being unloaded (contains the AST as well).
     ///
-    Sema* m_Sema;
+    clang::Sema* m_Sema;
 
     ///\brief The clang code generator, being recovered.
     ///
@@ -49,7 +50,7 @@ namespace clang {
     FileIDs m_FilesToUncache;
 
   public:
-    DeclUnloader(Sema* S, clang::CodeGenerator* CG, const Transaction* T)
+    DeclUnloader(clang::Sema* S, clang::CodeGenerator* CG, const Transaction* T)
       : m_Sema(S), m_CodeGen(CG), m_CurTransaction(T) { }
     ~DeclUnloader();
 
@@ -58,7 +59,7 @@ namespace clang {
     ///\param[in] D - The declaration to forward.
     ///\returns true on success.
     ///
-    bool UnloadDecl(Decl* D) { return Visit(D); }
+    bool UnloadDecl(clang::Decl* D) { return Visit(D); }
 
     ///\brief If it falls back in the base class just remove the declaration
     /// only from the declaration context.
@@ -66,7 +67,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitDecl(Decl* D);
+    bool VisitDecl(clang::Decl* D);
 
     ///\brief Removes the declaration from the lookup chains and from the
     /// declaration context.
@@ -74,14 +75,14 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitNamedDecl(NamedDecl* ND);
+    bool VisitNamedDecl(clang::NamedDecl* ND);
 
     ///\brief Removes the declaration from Sema's unused decl registry
     /// @param[in] DD - The declaration to be removed.
     ///
     ///\returns true on success.
     ///
-    bool VisitDeclaratorDecl(DeclaratorDecl* DD);
+    bool VisitDeclaratorDecl(clang::DeclaratorDecl* DD);
 
     ///\brief Removes a using shadow declaration, created in the cases:
     ///\code
@@ -97,7 +98,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitUsingShadowDecl(UsingShadowDecl* USD);
+    bool VisitUsingShadowDecl(clang::UsingShadowDecl* USD);
 
     ///\brief Removes a typedef name decls. A base class for TypedefDecls and
     /// TypeAliasDecls.
@@ -105,7 +106,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitTypedefNameDecl(TypedefNameDecl* TND);
+    bool VisitTypedefNameDecl(clang::TypedefNameDecl* TND);
 
     ///\brief Removes the declaration from the lookup chains and from the
     /// declaration context and it rebuilds the redeclaration chain.
@@ -113,7 +114,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitVarDecl(VarDecl* VD);
+    bool VisitVarDecl(clang::VarDecl* VD);
 
     ///\brief Removes the declaration from the lookup chains and from the
     /// declaration context and it rebuilds the redeclaration chain.
@@ -121,7 +122,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitFunctionDecl(FunctionDecl* FD);
+    bool VisitFunctionDecl(clang::FunctionDecl* FD);
 
     ///\brief Specialize the removal of constructors due to the fact the we need
     /// the constructor type (aka CXXCtorType). The information is located in
@@ -135,7 +136,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitCXXConstructorDecl(CXXConstructorDecl* CXXCtor);
+    bool VisitCXXConstructorDecl(clang::CXXConstructorDecl* CXXCtor);
 
     ///\brief Specialize the removal of destructors due to the fact the we need
     /// the to erase the dtor decl and the deleting operator.
@@ -147,21 +148,21 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitCXXDestructorDecl(CXXDestructorDecl* CXXDtor);
+    bool VisitCXXDestructorDecl(clang::CXXDestructorDecl* CXXDtor);
 
     ///\brief Removes the DeclCotnext and its decls.
     /// @param[in] DC - The declaration to be removed.
     ///
     ///\returns true on success.
     ///
-    bool VisitDeclContext(DeclContext* DC);
+    bool VisitDeclContext(clang::DeclContext* DC);
 
     ///\brief Removes the namespace.
     /// @param[in] NSD - The declaration to be removed.
     ///
     ///\returns true on success.
     ///
-    bool VisitNamespaceDecl(NamespaceDecl* NSD);
+    bool VisitNamespaceDecl(clang::NamespaceDecl* NSD);
 
     ///\brief Removes a Tag (class/union/struct/enum). Most of the other
     /// containers fall back into that case.
@@ -169,7 +170,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitTagDecl(TagDecl* TD);
+    bool VisitTagDecl(clang::TagDecl* TD);
 
     ///\brief Removes a RecordDecl. We shouldn't remove the implicit class
     /// declaration.
@@ -177,7 +178,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitRecordDecl(RecordDecl* RD);
+    bool VisitRecordDecl(clang::RecordDecl* RD);
 
     ///\brief Remove the macro from the Preprocessor.
     /// @param[in] MD - The MacroDirectiveInfo containing the IdentifierInfo and
@@ -196,7 +197,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitRedeclarableTemplateDecl(RedeclarableTemplateDecl* R);
+    bool VisitRedeclarableTemplateDecl(clang::RedeclarableTemplateDecl* R);
 
 
     ///\brief Removes the declaration clang's internal structures. This case
@@ -206,7 +207,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitFunctionTemplateDecl(FunctionTemplateDecl* FTD);
+    bool VisitFunctionTemplateDecl(clang::FunctionTemplateDecl* FTD);
 
     ///\brief Removes a class template declaration from clang's internal
     /// structures.
@@ -214,7 +215,7 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitClassTemplateDecl(ClassTemplateDecl* CTD);
+    bool VisitClassTemplateDecl(clang::ClassTemplateDecl* CTD);
 
     ///\brief Removes a class template specialization declaration from clang's
     /// internal structures.
@@ -222,12 +223,12 @@ namespace clang {
     ///
     ///\returns true on success.
     ///
-    bool VisitClassTemplateSpecializationDecl(ClassTemplateSpecializationDecl*
-                                              CTSD);
+    bool VisitClassTemplateSpecializationDecl(
+                                  clang::ClassTemplateSpecializationDecl* CTSD);
 
     ///@}
 
-    void MaybeRemoveDeclFromModule(GlobalDecl& GD) const;
+    void MaybeRemoveDeclFromModule(clang::GlobalDecl& GD) const;
 
     /// @name Helpers
     /// @{
@@ -250,16 +251,16 @@ namespace clang {
     /// declaration or a macro directive definition in the AST.
     ///\param[in] Loc - The source location of the unloaded declaration.
     ///
-    void CollectFilesToUncache(SourceLocation Loc);
+    void CollectFilesToUncache(clang::SourceLocation Loc);
 
     LLVM_CONSTEXPR static bool isDefinition(void*) { return false; }
-    static bool isDefinition(TagDecl* R);
+    static bool isDefinition(clang::TagDecl* R);
 
     static void resetDefinitionData(void*) {
       llvm_unreachable("resetDefinitionData on non-cxx record declaration");
     }
 
-    static void resetDefinitionData(TagDecl *decl);
+    static void resetDefinitionData(clang::TagDecl *decl);
 
     template<typename DeclT>
     static void removeRedeclFromChain(DeclT* R);
@@ -269,12 +270,8 @@ namespace clang {
     }
 
     template <typename T>
-    bool VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC);
+    bool VisitRedeclarable(clang::Redeclarable<T>* R, clang::DeclContext* DC);
   };
-} // namespace clang
-
-namespace cling {
-  using clang::DeclUnloader;
 
   /// \brief Unload a Decl from the AST, but not from CodeGen or Module.
   inline bool UnloadDecl(clang::Sema* S, clang::Decl* D) {
@@ -287,6 +284,7 @@ namespace cling {
     DeclUnloader Unloader(S, CG, nullptr);
     return Unloader.UnloadDecl(D);
   }
+
 } // namespace cling
 
 #endif // CLING_DECL_UNLOADER

--- a/lib/Interpreter/LookupHelper.cpp
+++ b/lib/Interpreter/LookupHelper.cpp
@@ -26,7 +26,7 @@
 
 using namespace clang;
 
-namespace clang {
+namespace cling {
 
   ///\brief Cleanup Parser state after a failed lookup.
   ///

--- a/lib/Interpreter/TransactionUnloader.cpp
+++ b/lib/Interpreter/TransactionUnloader.cpp
@@ -24,7 +24,7 @@ using namespace clang;
 
 namespace cling {
   bool TransactionUnloader::unloadDeclarations(Transaction* T,
-                                               clang::DeclUnloader& DeclU) {
+                                               DeclUnloader& DeclU) {
     bool Successful = true;
 
     for (Transaction::const_reverse_iterator I = T->rdecls_begin(),
@@ -61,7 +61,7 @@ namespace cling {
   }
 
   bool TransactionUnloader::unloadFromPreprocessor(Transaction* T,
-                                                   clang::DeclUnloader& DeclU) {
+                                                   DeclUnloader& DeclU) {
     bool Successful = true;
     for (Transaction::const_reverse_macros_iterator MI = T->rmacros_begin(),
            ME = T->rmacros_end(); MI != ME; ++MI) {
@@ -75,7 +75,7 @@ namespace cling {
   }
 
   bool TransactionUnloader::unloadDeserializedDeclarations(Transaction* T,
-                                                   clang::DeclUnloader& DeclU) {
+                                                   DeclUnloader& DeclU) {
     //FIXME: Terrible hack, we *must* get rid of parseForModule by implementing
     // a header file generator in cling.
     bool Successful = true;
@@ -150,4 +150,3 @@ namespace cling {
     return true;
   }
 } // end namespace cling
-

--- a/lib/Interpreter/TransactionUnloader.h
+++ b/lib/Interpreter/TransactionUnloader.h
@@ -17,7 +17,6 @@ namespace llvm {
 namespace clang {
   class CodeGenerator;
   class Decl;
-  class DeclUnloader;
   class Sema;
 }
 
@@ -26,6 +25,7 @@ namespace cling {
   class IncrementalExecutor;
   class Interpreter;
   class Transaction;
+  class DeclUnloader;
 
   ///\brief A simple eraser class that removes already created AST Nodes.
   ///
@@ -36,10 +36,10 @@ namespace cling {
     clang::CodeGenerator* m_CodeGen;
     cling::IncrementalExecutor* m_Exe;
 
-    bool unloadDeclarations(Transaction* T, clang::DeclUnloader& DeclU);
+    bool unloadDeclarations(Transaction* T, DeclUnloader& DeclU);
     bool unloadDeserializedDeclarations(Transaction* T,
-                                        clang::DeclUnloader& DeclU);
-    bool unloadFromPreprocessor(Transaction* T, clang::DeclUnloader& DeclU);
+                                        DeclUnloader& DeclU);
+    bool unloadFromPreprocessor(Transaction* T, DeclUnloader& DeclU);
     bool unloadModule(llvm::Module* M);
 
   public:


### PR DESCRIPTION
Requires changes to clang here:
https://github.com/marsupial/clang/commit/bb84e42bcd751fdc10024b9e2a0c66c3c7afadc1