### PR TITLE
extern "C" declarations & cruft removal

### DIFF
--- a/include/cling/Interpreter/Transaction.h
+++ b/include/cling/Interpreter/Transaction.h
@@ -185,12 +185,7 @@ namespace cling {
     ///
     clang::FileID m_BufferFID;
 
-    ///\brief This is all to support allocation via TransactionPool.
-    /// There is currently no way for TransactionPool to mark if a Transaction
-    /// originated there or elsewhere, so if this interface is needed
-    /// then TransactionPool will have to be rewritten (or even removed
-    /// as the performance gains seem negligable)
-    ///
+    /// TransactionPool needs direct access to m_State as setState asserts
     friend class TransactionPool;
 
     void Initialize(clang::Sema& S);

--- a/lib/Interpreter/InvocationOptions.cpp
+++ b/lib/Interpreter/InvocationOptions.cpp
@@ -65,11 +65,8 @@ namespace {
     Opts.NoLogo = Args.hasArg(OPT__nologo);
     Opts.ShowVersion = Args.hasArg(OPT_version);
     Opts.Help = Args.hasArg(OPT_help);
-    if (Args.hasArg(OPT__metastr, OPT__metastr_EQ)) {
-      if (Arg* MetaStringArg = Args.getLastArg(OPT__metastr, OPT__metastr_EQ))
-        Opts.MetaString = MetaStringArg->getValue();
-      else
-        Opts.MetaString.clear();
+    if (Arg* MetaStringArg = Args.getLastArg(OPT__metastr, OPT__metastr_EQ)) {
+      Opts.MetaString = MetaStringArg->getValue();
       if (Opts.MetaString.empty()) {
         llvm::errs() << "ERROR: meta string must be non-empty! Defaulting to '.'.\n";
         Opts.MetaString = ".";

--- a/lib/Interpreter/Transaction.cpp
+++ b/lib/Interpreter/Transaction.cpp
@@ -62,12 +62,22 @@ namespace cling {
   }
 
   NamedDecl* Transaction::containsNamedDecl(llvm::StringRef name) const {
-    for (auto I = decls_begin(), E = decls_end(); I < E; ++I)
+    for (auto I = decls_begin(), E = decls_end(); I < E; ++I) {
       for (auto DI : I->m_DGR) {
-        if (NamedDecl* ND = dyn_cast<NamedDecl>(DI))
+        if (NamedDecl* ND = dyn_cast<NamedDecl>(DI)) {
           if (name.equals(ND->getNameAsString()))
             return ND;
+        }
+        else if (LinkageSpecDecl* LSD = dyn_cast<LinkageSpecDecl>(DI)) {
+          for (Decl* DI : LSD->decls()) {
+            if (NamedDecl* ND = dyn_cast<NamedDecl>(DI)) {
+              if (name.equals(ND->getNameAsString()))
+                return ND;
+            }
+          }
+        }
       }
+    }
     return 0;
   }
 

--- a/lib/Interpreter/TransactionPool.h
+++ b/lib/Interpreter/TransactionPool.h
@@ -57,6 +57,8 @@ namespace cling {
       return T;
     }
 
+    // Transaction T must be from call to TransactionPool::takeTransaction
+    //
     void releaseTransaction(Transaction* T, bool reuse = true) {
       if (reuse) {
         assert((T->getState() == Transaction::kCompleted ||

--- a/test/Lookup/linkageSpec.C
+++ b/test/Lookup/linkageSpec.C
@@ -1,0 +1,22 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: %cling %s -Xclang -verify 2>&1 | FileCheck %s
+
+// This test assures that extern "C" declarations are usable via .x
+
+extern "C" int printf(const char*, ...);
+
+extern "C" int linkageSpec() {
+  printf("linkageSpec called %s\n", __FUNCTION__);
+  return 101;
+}
+
+// CHECK: linkageSpec called linkageSpec
+// CHECK: (int) 101
+// expected-no-diagnostics


### PR DESCRIPTION
Allow extern "C" declarations to be called from .x command.
Fix some cruft and now invalid comments built up from commits earlier this week.
