### PR TITLE
Does not ignore IPKernelApp.init_io

### DIFF
--- a/tools/Jupyter/kernel/clingkernel.py
+++ b/tools/Jupyter/kernel/clingkernel.py
@@ -281,10 +281,7 @@ class ClingKernel(Kernel):
 
 class ClingKernelApp(IPKernelApp):
     kernel_class = ClingKernel
-    def init_io(self):
-        # disable io forwarding
-        pass
-
+    
 
 def main():
     """launch a cling kernel"""


### PR DESCRIPTION
In latest jupyter versions this fixes AttributeError 'ClingKernelApp object has no attribute displayhook'