### PR TITLE
Use std::pair instead of llvm::PointerIntPair.

### DIFF
--- a/lib/Interpreter/IncrementalExecutor.cpp
+++ b/lib/Interpreter/IncrementalExecutor.cpp
@@ -329,13 +329,13 @@ IncrementalExecutor::installLazyFunctionCreator(LazyFunctionCreatorFunc_t fp)
 
 bool
 IncrementalExecutor::addSymbol(const char* symbolName,  void* symbolAddress) {
-  return IncrementalJIT::searchLibraries(symbolName, symbolAddress).getInt();
+  return IncrementalJIT::searchLibraries(symbolName, symbolAddress).second;
 }
 
 void* IncrementalExecutor::getAddressOfGlobal(llvm::StringRef symbolName,
                                               bool* fromJIT /*=0*/) {
   // Return a symbol's address, and whether it was jitted.
-  void* address = IncrementalJIT::searchLibraries(symbolName).getPointer();
+  void* address = IncrementalJIT::searchLibraries(symbolName).first;
 
   // It's not from the JIT if it's in a dylib.
   if (fromJIT)

--- a/lib/Interpreter/IncrementalJIT.cpp
+++ b/lib/Interpreter/IncrementalJIT.cpp
@@ -212,7 +212,7 @@ IncrementalJIT::getInjectedSymbols(const std::string& Name) const {
   return JITSymbol(nullptr);
 }
 
-llvm::PointerIntPair<void*, 1>
+std::pair<void*, bool>
 IncrementalJIT::searchLibraries(llvm::StringRef Name, void *InAddr) {
   // FIXME: See comments on DLSym below.
 #if !defined(LLVM_ON_WIN32)
@@ -223,9 +223,9 @@ IncrementalJIT::searchLibraries(llvm::StringRef Name, void *InAddr) {
 
   if (InAddr && !Addr) {
     llvm::sys::DynamicLibrary::AddSymbol(Name, InAddr);
-    return llvm::PointerIntPair<void*, 1>(InAddr, true);
+    return std::make_pair(InAddr, true);
   }
-  return llvm::PointerIntPair<void*, 1>(Addr, false);
+  return std::make_pair(Addr, false);
 }
     
 llvm::orc::JITSymbol

--- a/lib/Interpreter/IncrementalJIT.h
+++ b/lib/Interpreter/IncrementalJIT.h
@@ -218,7 +218,7 @@ public:
   /// \param Name - symbol to look for
   /// \param Addr - known address of the symbol that can be cached later use
   /// \returns The address of the symbol and whether it was cached
-  static llvm::PointerIntPair<void*, 1>
+  static std::pair<void*, bool>
   searchLibraries(llvm::StringRef Name, void* Addr = nullptr);
 };
 } // end cling

--- a/test/Interfaces/address.C
+++ b/test/Interfaces/address.C
@@ -47,11 +47,32 @@ if (!fromJIT) printf("N::gMyGlobal should come from JIT!\n");
 printf("N::gMyGlobal: %s\n", comp(addrN1, addrN2)); //CHECK: N::gMyGlobal: equal
 
 .L address_lib
-extern "C" int gLibGlobal;
+extern "C" {
+  int gLibGlobal;
+  extern const char gByteAlign0, gByteAlign1, gByteAlign2, gByteAlign3;
+}
+
 void* addrL1 = &gLibGlobal;
 fromJIT = true;
 VD = llvm::cast<clang::VarDecl>(cling::utils::Lookup::Named(&sema, "gLibGlobal"));
 if (!VD) printf("gLibGlobal decl not found!\n");
 void* addrL2 = gCling->getAddressOfGlobal(clang::GlobalDecl(VD), &fromJIT);
 if (fromJIT) printf("gLibGlobal should NOT come from JIT!\n");
-printf("gLibGlobal: %s\n", comp(addrL1, addrL2)); //CHECK: gLibGlobal: equal
+printf("gLibGlobal: %s\n", comp(addrL1, addrL2)); //CHECK-NEXT: gLibGlobal: equal
+
+static bool symalign(clang::Sema& sema) {
+  bool b0, b1, b2, b3;
+  clang::VarDecl
+  *g0 = llvm::cast<clang::VarDecl>(cling::utils::Lookup::Named(&sema, "gByteAlign0")),
+  *g1 = llvm::cast<clang::VarDecl>(cling::utils::Lookup::Named(&sema, "gByteAlign1")),
+  *g2 = llvm::cast<clang::VarDecl>(cling::utils::Lookup::Named(&sema, "gByteAlign2")),
+  *g3 = llvm::cast<clang::VarDecl>(cling::utils::Lookup::Named(&sema, "gByteAlign3"));
+
+  gCling->getAddressOfGlobal(clang::GlobalDecl(g0), &b0);
+  gCling->getAddressOfGlobal(clang::GlobalDecl(g1), &b1);
+  gCling->getAddressOfGlobal(clang::GlobalDecl(g2), &b2);
+  gCling->getAddressOfGlobal(clang::GlobalDecl(g3), &b3);
+  return !b0 && !b1 && !b2 && !b3;
+}
+symalign(sema)
+// CHECK-NEXT: (bool) true

--- a/test/Interfaces/address_lib.c
+++ b/test/Interfaces/address_lib.c
@@ -9,3 +9,6 @@
 // RUN: true
 // Used as library source by address.C
 int gLibGlobal = 14;
+
+#pragma pack(1)
+const char gByteAlign0 = 0, gByteAlign1 = 1, gByteAlign2 = 2, gByteAlign3 = 3;


### PR DESCRIPTION
Fixes issues where symbols are not 16 bit aligned.