### PR TITLE
TTY fixes

### DIFF
--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -352,7 +352,9 @@ namespace {
     Opts.RTTIData = 0;
     Opts.setDefaultCallingConv(clang::LangOptions::DCC_CDecl);
 #ifdef _DEBUG
-    Opts.setStackProtector(clang::LangOptions::SSPStrong);
+    // FIXME: This requires bufferoverflowu.lib, but adding:
+    // #pragma comment(lib, "bufferoverflowu.lib") still gives errors!
+    // Opts.setStackProtector(clang::LangOptions::SSPStrong);
 #endif
 #else
     Opts.Exceptions = 1;

--- a/lib/UserInterface/textinput/TerminalDisplayUnix.cpp
+++ b/lib/UserInterface/textinput/TerminalDisplayUnix.cpp
@@ -124,9 +124,7 @@ namespace textinput {
   }
 
   static void syncOut(int fd) {
-    ::fsync(fd);
-    //if (fd != STDOUT_FILENO)
-      ::fflush(stdout);
+    ::fflush(stdout);
   }
 
   TerminalDisplayUnix::~TerminalDisplayUnix() {

--- a/lib/UserInterface/textinput/TerminalDisplayUnix.h
+++ b/lib/UserInterface/textinput/TerminalDisplayUnix.h
@@ -50,6 +50,7 @@ namespace textinput {
   private:
     bool fIsAttached; // whether tty is configured
     size_t fNColors; // number of colors supported by output
+    int fOutputID; // Prompt output file descriptor
   };
 }
 #endif // TEXTINPUT_TERMINALDISPLAYUNIX_H

--- a/lib/UserInterface/textinput/TerminalDisplayWin.cpp
+++ b/lib/UserInterface/textinput/TerminalDisplayWin.cpp
@@ -15,34 +15,38 @@
 
 #ifdef _WIN32
 #include "textinput/TerminalDisplayWin.h"
-
 #include "textinput/Color.h"
+
+#include <assert.h>
 
 namespace textinput {
   TerminalDisplayWin::TerminalDisplayWin():
     TerminalDisplay(false), fStartLine(0), fIsAttached(false),
     fDefaultAttributes(0) {
+    DWORD mode;
+    SetIsTTY(::GetConsoleMode(::GetStdHandle(STD_INPUT_HANDLE), &mode) != 0);
+
     fOut = ::GetStdHandle(STD_OUTPUT_HANDLE);
     bool isConsole = ::GetConsoleMode(fOut, &fOldMode) != 0;
-    SetIsTTY(isConsole);
-    if (isConsole) {
+    if (!isConsole) {
       // Prevent redirection from stealing our console handle,
       // simply open our own.
       fOut = ::CreateFileA("CONOUT$", GENERIC_READ | GENERIC_WRITE,
         FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, OPEN_EXISTING,
         FILE_ATTRIBUTE_NORMAL, NULL);
       ::GetConsoleMode(fOut, &fOldMode);
-      fMyMode = fOldMode | ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT;
 
       CONSOLE_SCREEN_BUFFER_INFO csbi;
       ::GetConsoleScreenBufferInfo(fOut, &csbi);
       fDefaultAttributes = csbi.wAttributes;
+      assert(fDefaultAttributes != 0 && "~TerminalDisplayWin broken");
     }
+    fMyMode = fOldMode | ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT;
     HandleResizeEvent();
   }
 
   TerminalDisplayWin::~TerminalDisplayWin() {
-    if (IsTTY()) {
+    if (fDefaultAttributes) {
       ::SetConsoleTextAttribute(fOut, fDefaultAttributes);
       // We allocated CONOUT$:
       CloseHandle(fOut);
@@ -80,6 +84,7 @@ namespace textinput {
 
   void
   TerminalDisplayWin::CheckCursorPos() {
+    if (!IsTTY()) return;
     // Did something print something on the screen?
     // I.e. did the cursor move?
     CONSOLE_SCREEN_BUFFER_INFO CSI;
@@ -108,8 +113,10 @@ namespace textinput {
 
   void
   TerminalDisplayWin::MoveInternal(Pos P) {
-    COORD C = {P.fCol, P.fLine + fStartLine};
-    ::SetConsoleCursorPosition(fOut, C);
+    if (IsTTY()) {
+      COORD C = {P.fCol, P.fLine + fStartLine};
+      ::SetConsoleCursorPosition(fOut, C);
+    }
   }
 
   void
@@ -174,21 +181,19 @@ namespace textinput {
   void
   TerminalDisplayWin::Attach() {
     // set to noecho
-    if (fIsAttached) return;
-    if (IsTTY() && !::SetConsoleMode(fOut, fMyMode)) {
+    if (fIsAttached || !IsTTY()) return;
+    if (!::SetConsoleMode(fOut, fMyMode)) {
       ShowError("attaching to console output");
     }
     CONSOLE_SCREEN_BUFFER_INFO Info;
-    if (IsTTY()) {
-      if (!::GetConsoleScreenBufferInfo(fOut, &Info)) {
-        ShowError("attaching / getting console info");
-      } else {
-        fStartLine = Info.dwCursorPosition.Y;
-        if (Info.dwCursorPosition.X) {
-          // Whooa - where are we?! Newline and cross fingers:
-          WriteRawString("\n", 1);
-          ++fStartLine;
-        }
+    if (!::GetConsoleScreenBufferInfo(fOut, &Info)) {
+      ShowError("attaching / getting console info");
+    } else {
+      fStartLine = Info.dwCursorPosition.Y;
+      if (Info.dwCursorPosition.X) {
+        // Whooa - where are we?! Newline and cross fingers:
+        WriteRawString("\n", 1);
+        ++fStartLine;
       }
     }
     fIsAttached = true;
@@ -196,8 +201,8 @@ namespace textinput {
 
   void
   TerminalDisplayWin::Detach() {
-    if (!fIsAttached) return;
-    if (IsTTY() && !SetConsoleMode(fOut, fOldMode)) {
+    if (!fIsAttached || !IsTTY()) return;
+    if (!SetConsoleMode(fOut, fOldMode)) {
       ShowError("detaching to console output");
     }
     TerminalDisplay::Detach();


### PR DESCRIPTION
Windows currently dumps input so `cat F.C | cling.exe` will show F.C contents on the console.
Make `cling > Out.log` show `[cling$]` prompt.