### PR TITLE
Platform specific fixes.

### DIFF
--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -649,12 +649,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     GD = GlobalDecl(CXXDtor, Dtor_Base);
     MaybeRemoveDeclFromModule(GD);
     GD = GlobalDecl(CXXDtor, Dtor_Comdat);
-#if defined(LLVM_ON_WIN32)
-    // MicrosoftMangle.cpp:954 calls llvm_unreachable when mangling Dtor_Comdat
-    MaybeRemoveDeclFromModule(GD, false);
-#else
     MaybeRemoveDeclFromModule(GD);
-#endif
 
     bool Successful = VisitCXXMethodDecl(CXXDtor);
     return Successful;
@@ -734,8 +729,7 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     return Successful;
   }
 
-  void DeclUnloader::MaybeRemoveDeclFromModule(GlobalDecl& GD,
-                                               bool Mangle) const {
+  void DeclUnloader::MaybeRemoveDeclFromModule(GlobalDecl& GD) const {
     if (!m_CurTransaction
         || !m_CurTransaction->getModule()) // syntax-only mode exit
       return;
@@ -778,31 +772,24 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
     //
     if (m_CurTransaction->getState() == Transaction::kCommitted) {
       std::string mangledName;
-      if (LLVM_UNLIKELY(!Mangle)) {
-        const NamedDecl* D = cast<NamedDecl>(const_cast<Decl*>(GD.getDecl()));
-        if (const IdentifierInfo *II = D->getIdentifier())
-          mangledName = II->getName();
-      } else
-        utils::Analyze::maybeMangleDeclName(GD, mangledName);
+      utils::Analyze::maybeMangleDeclName(GD, mangledName);
 
-      if (LLVM_LIKELY(!mangledName.empty())) {
-        // Handle static locals. void func() { static int var; } is represented
-        // in the llvm::Module is a global named @func.var
-        if (const VarDecl* VD = dyn_cast<VarDecl>(GD.getDecl())) {
-          if (VD->isStaticLocal()) {
-            std::string functionMangledName;
-            GlobalDecl FDGD(cast<FunctionDecl>(VD->getDeclContext()));
-            utils::Analyze::maybeMangleDeclName(FDGD, functionMangledName);
-            mangledName = functionMangledName + "." + mangledName;
-          }
+      // Handle static locals. void func() { static int var; } is represented
+      // in the llvm::Module is a global named @func.var
+      if (const VarDecl* VD = dyn_cast<VarDecl>(GD.getDecl())) {
+        if (VD->isStaticLocal()) {
+          std::string functionMangledName;
+          GlobalDecl FDGD(cast<FunctionDecl>(VD->getDeclContext()));
+          utils::Analyze::maybeMangleDeclName(FDGD, functionMangledName);
+          mangledName = functionMangledName + "." + mangledName;
         }
+      }
 
-        llvm::Module* M = m_CurTransaction->getModule();
-        GlobalValue* GV = M->getNamedValue(mangledName);
-        if (GV) { // May be deferred decl and thus 0
-          GlobalValueEraser GVEraser(m_CodeGen);
-          GVEraser.EraseGlobalValue(GV);
-        }
+      llvm::Module* M = m_CurTransaction->getModule();
+      GlobalValue* GV = M->getNamedValue(mangledName);
+      if (GV) { // May be deferred decl and thus 0
+        GlobalValueEraser GVEraser(m_CodeGen);
+        GVEraser.EraseGlobalValue(GV);
       }
       m_CodeGen->forgetDecl(GD);
     }

--- a/lib/Interpreter/DeclUnloader.cpp
+++ b/lib/Interpreter/DeclUnloader.cpp
@@ -274,7 +274,9 @@ bool DeclUnloader::VisitRedeclarable(clang::Redeclarable<T>* R, DeclContext* DC)
           MarkConstant(GV->getInitializer());
       } else if (GlobalAlias *GA = dyn_cast<GlobalAlias>(G)) {
         // The target of a global alias as referenced.
-        MarkConstant(GA->getAliasee());
+        // GA->getAliasee() is sometimes returning NULL on Windows
+        if (llvm::Constant* C = GA->getAliasee())
+          MarkConstant(C);
       } else {
         // Otherwise this must be a function object.  We have to scan the body
         // of the function looking for constants and global values which are

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -228,7 +228,8 @@ namespace cling {
 
     ///@}
 
-    void MaybeRemoveDeclFromModule(clang::GlobalDecl& GD) const;
+    void MaybeRemoveDeclFromModule(clang::GlobalDecl& GD,
+                                   bool Mangle = true) const;
 
     /// @name Helpers
     /// @{

--- a/lib/Interpreter/DeclUnloader.h
+++ b/lib/Interpreter/DeclUnloader.h
@@ -228,8 +228,7 @@ namespace cling {
 
     ///@}
 
-    void MaybeRemoveDeclFromModule(clang::GlobalDecl& GD,
-                                   bool Mangle = true) const;
+    void MaybeRemoveDeclFromModule(clang::GlobalDecl& GD) const;
 
     /// @name Helpers
     /// @{

--- a/lib/Utils/AST.cpp
+++ b/lib/Utils/AST.cpp
@@ -86,8 +86,17 @@ namespace utils {
       //Dtor_Deleting, // Deleting dtor
       //Dtor_Complete, // Complete object dtor
       //Dtor_Base      // Base object dtor
-      mangleCtx->mangleCXXDtor(cast<CXXDestructorDecl>(D),
-                               GD.getDtorType(), RawStr);
+#if defined(LLVM_ON_WIN32)
+      // MicrosoftMangle.cpp:954 calls llvm_unreachable when mangling Dtor_Comdat
+      if (GD.getDtorType() == Dtor_Comdat) {
+        if (const IdentifierInfo* II = D->getIdentifier())
+          RawStr << II->getName();
+      } else
+#endif
+      {
+        mangleCtx->mangleCXXDtor(cast<CXXDestructorDecl>(D),
+                                 GD.getDtorType(), RawStr);
+      }
       break;
 
     default :

--- a/test/Pragmas/add_env_path.C
+++ b/test/Pragmas/add_env_path.C
@@ -11,20 +11,15 @@
 
 extern "C" int cling_testlibrary_function();
 
-// For gcc setenv
-#ifndef __THROW
- #define __THROW
-#endif
-extern "C" int setenv(const char *name, const char *value, int overwrite) __THROW;
-extern "C" int _putenv_s(const char *name, const char *value);
-static void setup() {
-#ifdef _WIN32
+#ifndef _WIN32
+ #include <stdlib.h>
+#else
+ extern "C" int _putenv_s(const char *name, const char *value);
  #define setenv(n, v, o) _putenv_s(n,v)
 #endif
-  ::setenv("ENVVAR_INC", ENVVAR_INC, 1);
-  ::setenv("ENVVAR_LIB", ENVVAR_LIB, 1);
-}
-setup();
+
+::setenv("ENVVAR_INC", ENVVAR_INC, 1);
+::setenv("ENVVAR_LIB", ENVVAR_LIB, 1);
 
 #pragma cling add_include_path("$ENVVAR_INC")
 #include "Include_header.h"


### PR DESCRIPTION
LLVM cannot mangle Dtor_Comdat on Windows.
Some constants are not aliased.
GCC on OS X doesn't like setting declaration.