### PR TITLE
Intercept atexit calls.

### DIFF
--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -274,17 +274,16 @@ namespace cling {
                                                 llvm::StringRef code,
                                                 bool withAccessControl);
 
-    ///\brief Include C++ runtime headers and definitions.
+    ///\brief Initialize runtime and C/C++ level overrides
     ///
-    void IncludeCXXRuntime();
-
-    ///\brief Include C runtime headers and definitions.
+    ///\param[in] NoRuntime - Don't include the runtime headers / gCling
+    ///\param[in] SyntaxOnly - In SyntaxOnly mode
+    ///\param[out] Globals - Global symbols that need to be emitted
     ///
-    void IncludeCRuntime();
-
-    ///\brief Init atexit runtime delegation.
+    ///\returns The resulting Transation of initialization.
     ///
-    void InitAExit();
+    Transaction* Initialize(bool NoRuntime, bool SyntaxOnly,
+                            llvm::SmallVectorImpl<llvm::StringRef>& Globals);
 
     ///\brief The target constructor to be called from both the delegating
     /// constructors. parentInterp might be nullptr.

--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -282,6 +282,10 @@ namespace cling {
     ///
     void IncludeCRuntime();
 
+    ///\brief Init atexit runtime delegation.
+    ///
+    void InitAExit();
+
     ///\brief The target constructor to be called from both the delegating
     /// constructors. parentInterp might be nullptr.
     ///

--- a/lib/Interpreter/IncrementalExecutor.h
+++ b/lib/Interpreter/IncrementalExecutor.h
@@ -114,10 +114,6 @@ namespace cling {
     ///
     AtExitFunctions m_AtExitFuncs;
 
-    ///\brief Module for which registration of static destructors currently
-    /// takes place.
-    llvm::Module* m_CurrentAtExitModule;
-
     ///\brief Modules to emit upon the next call to the JIT.
     ///
     std::vector<llvm::Module*> m_ModulesToJIT;
@@ -208,12 +204,13 @@ namespace cling {
     /// Allows runtime declaration of a function passing its pointer for being
     /// used by JIT generated code.
     ///
-    /// @param[in] symbolName - The name of the symbol as required by the
+    /// @param[in] Name - The name of the symbol as required by the
     ///                         linker (mangled if needed)
-    /// @param[in] symbolAddress - The function pointer to register
+    /// @param[in] Address - The function pointer to register
+    /// @param[in] JIT - Add to the JIT injected symbol table
     /// @returns true if the symbol is successfully registered, false otherwise.
     ///
-    bool addSymbol(const char* symbolName,  void* symbolAddress);
+    bool addSymbol(const char* Name, void* Address, bool JIT = false);
 
     ///\brief Add a llvm::Module to the JIT.
     ///
@@ -251,7 +248,7 @@ namespace cling {
 
     ///\brief Keep track of the entities whose dtor we need to call.
     ///
-    void AddAtExitFunc(void (*func) (void*), void* arg);
+    void AddAtExitFunc(void (*func) (void*), void* arg, llvm::Module* M);
 
     ///\brief Try to resolve a symbol through our LazyFunctionCreators;
     /// print an error message if that fails.

--- a/lib/Interpreter/IncrementalJIT.cpp
+++ b/lib/Interpreter/IncrementalJIT.cpp
@@ -26,9 +26,10 @@ using namespace llvm;
 
 namespace {
 // Forward cxa_atexit for global d'tors.
-static void local_cxa_atexit(void (*func) (void*), void* arg, void* dso) {
+static int local_cxa_atexit(void (*func) (void*), void* arg, void* dso) {
   cling::IncrementalExecutor* exe = (cling::IncrementalExecutor*)dso;
   exe->AddAtExitFunc(func, arg);
+  return 0;
 }
 
 ///\brief Memory manager providing the lop-level link to the

--- a/lib/Interpreter/IncrementalJIT.h
+++ b/lib/Interpreter/IncrementalJIT.h
@@ -215,9 +215,10 @@ public:
   ///\brief Get the address of a symbol from the process' loaded libraries.
   /// \param Name - symbol to look for
   /// \param Addr - known address of the symbol that can be cached later use
+  /// \param Jit - add to the injected symbols cache
   /// \returns The address of the symbol and whether it was cached
-  static std::pair<void*, bool>
-  searchLibraries(llvm::StringRef Name, void* Addr = nullptr);
+  std::pair<void*, bool>
+  lookupSymbol(llvm::StringRef Name, void* Addr = nullptr, bool Jit = false);
 };
 } // end cling
 #endif // CLING_INCREMENTAL_EXECUTOR_H

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -346,11 +346,9 @@ namespace cling {
       Strm << Linkage << " int __cxa_atexit(void (*f)(void*), void*, void*);\n";
 
       // C atexit, std::atexit
-#if !defined(LLVM_ON_WIN32) || !defined(_M_CEE_PURE)
       Strm << Linkage << " int atexit(void(*f)()) { "
            "return __cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); }\n";
       Globals.push_back("atexit");
-#endif
 
       // C++ 11 at_quick_exit, std::at_quick_exit
       if (LangOpts.CPlusPlus && LangOpts.CPlusPlus11) {
@@ -377,22 +375,6 @@ namespace cling {
          "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;}\n";
       Globals.push_back("_onexit");
  #endif
- #if defined(_M_CEE) || defined(_M_CEE_PURE)
-  #ifdef _M_CEE_MIXED
-      Strm << Linkage << " int __clrcall _atexit_m(_onexit_t f) { "
-         "return __cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); }\n";
-      Globals.push_back("_atexit_m");
-      Strm << Linkage << " _onexit_t_m __clrcall _onexit_m(_onexit_t f) { "
-         "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f; }\n";
-      Globals.push_back("_onexit_m");
-  #endif
-      Strm << Linkage << " _onexit_t_m __clrcall _onexit_m_appdomain(_onexit_t f) { "
-         "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f; }\n";
-      Globals.push_back("_onexit_m_appdomain");
-      Strm << Linkage << " int __clrcall _atexit_m_appdomain(_onexit_t f) { "
-         "return __cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); }\n";
-      Globals.push_back("_atexit_m_appdomain");
- #endif
 #endif
 
       // Override the native symbols now, before anything can be emitted.
@@ -402,7 +384,7 @@ namespace cling {
     }
 
     if (m_Opts.Verbose())
-      llvm::errs() << Strm.str();
+      cling::errs() << Strm.str();
 
     Transaction *T;
     declare(Strm.str(), &T);

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -347,13 +347,13 @@ namespace cling {
 
       // C atexit, std::atexit
       Strm << Linkage << " int atexit(void(*f)()) { "
-           "return __cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); }\n";
+           "return __cxa_atexit((void(*)(void*))f, 0, __dso_handle); }\n";
       Globals.push_back("atexit");
 
       // C++ 11 at_quick_exit, std::at_quick_exit
       if (LangOpts.CPlusPlus && LangOpts.CPlusPlus11) {
           Strm << Linkage << " int at_quick_exit(void(*f)()) { "
-           "return __cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); }\n";
+           "return __cxa_atexit((void(*)(void*))f, 0, __dso_handle); }\n";
         Globals.push_back("at_quick_exit");
       }
 
@@ -367,13 +367,13 @@ namespace cling {
       Strm << Linkage << " " << Spec << " int (*__dllonexit("
            << "int (" << Spec << " *f)(void**, void**), void**, void**))"
            "(void**, void**) { "
-           "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;"
+           "__cxa_atexit((void(*)(void*))f, 0, __dso_handle); return f;"
            "}\n";
       Globals.push_back("__dllonexit");
  #if !defined(_M_CEE_PURE)
       Strm << Linkage << " " << Spec << " int (*_onexit("
            << "int (" << Spec << 	" *f)()))() { "
-           "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;"
+           "__cxa_atexit((void(*)(void*))f, 0, __dso_handle); return f;"
            "}\n";
       Globals.push_back("_onexit");
  #endif

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -359,20 +359,22 @@ namespace cling {
 
 #if defined(LLVM_ON_WIN32)
       // Windows specific: _onexit, _onexit_m, __dllonexit
-      if (NoRuntime) {
-        // Have to declare the function pointer types now and hope no conflicts.
  #if !defined(_M_CEE)
-        Strm << "typedef int (__cdecl* _onexit_t)(void)\n;";
+      const char* Spec = "__cdecl";
  #else
-        Strm << "typedef int (__clrcall* _onexit_t)(void)\n";
+      const char* Spec = "__clrcall";
  #endif
-      }
-      Strm << Linkage << " _onexit_t __dllonexit(_onexit_t f, void**, void**) { "
-         "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;}\n";
+      Strm << Linkage << " " << Spec << " int (*__dllonexit("
+           << "int (" << Spec << " *f)(void**, void**), void**, void**))"
+           "(void**, void**) { "
+           "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;"
+           "}\n";
       Globals.push_back("__dllonexit");
  #if !defined(_M_CEE_PURE)
-      Strm << Linkage << " _onexit_t _onexit(_onexit_t f) { "
-         "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;}\n";
+      Strm << Linkage << " " << Spec << " int (*_onexit("
+           << "int (" << Spec << 	" *f)()))() { "
+           "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;"
+           "}\n";
       Globals.push_back("_onexit");
  #endif
 #endif

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -57,6 +57,13 @@ using namespace clang;
 
 namespace {
 
+  // Forward cxa_atexit for global d'tors.
+  static int local_cxa_atexit(void (*func) (void*), void* arg,
+                              cling::Interpreter* Interp) {
+    Interp->AddAtExitFunc(func, arg);
+    return 0;
+  }
+
   static cling::Interpreter::ExecutionResult
   ConvertExecutionResult(cling::IncrementalExecutor::ExecutionResult ExeRes) {
     switch (ExeRes) {
@@ -188,16 +195,30 @@ namespace cling {
 
     handleFrontendOptions();
 
-    if (!noRuntime) {
-      if (getCI()->getLangOpts().CPlusPlus)
-        IncludeCXXRuntime();
-      else
-        IncludeCRuntime();
-    }
+    llvm::SmallVector<llvm::StringRef, 6> Syms;
+    Initialize(noRuntime, isInSyntaxOnlyMode(), Syms);
+
     // Commit the transactions, now that gCling is set up. It is needed for
     // static initialization in these transactions through local_cxa_atexit().
     for (auto&& I: IncrParserTransactions)
       m_IncrParser->commitTransaction(I);
+
+    // Now that the transactions have been commited, force symbol emission
+    // and overrides.
+    if (const Transaction* T = getLastTransaction()) {
+      if (llvm::Module* M = T->getModule()) {
+        for (const llvm::StringRef& Sym : Syms) {
+          if (const llvm::GlobalValue* GV = M->getNamedValue(Sym)) {
+            if (void* Addr = m_Executor->getPointerToGlobalFromJIT(*GV))
+              m_Executor->addSymbol(Sym.str().c_str(), Addr, true);
+            else
+              cling::errs() << Sym << " not defined\n";
+          } else
+            cling::errs() << Sym << " not in Module!\n";
+        }
+      }
+    }
+
     // Disable suggestions for ROOT
     bool showSuggestions = !llvm::StringRef(ClingStringify(CLING_VERSION)).startswith("ROOT");
 
@@ -216,8 +237,6 @@ namespace cling {
       // Prevents stripping the symbol due to dead-code optimization.
       internal::symbol_requester();
     }
-
-    InitAExit();
   }
 
   ///\brief Constructor for the child Interpreter.
@@ -278,63 +297,93 @@ namespace cling {
     }
   }
 
-  void Interpreter::InitAExit() {
-    if (isInSyntaxOnlyMode())
-      return;
-
-    const char* Linkage = getCI()->getLangOpts().CPlusPlus ? "extern \"C\"" : "";
-    llvm::SmallString<512> Buf;
+  Transaction* Interpreter::Initialize(bool NoRuntime, bool SyntaxOnly,
+                              llvm::SmallVectorImpl<llvm::StringRef>& Globals) {
+    llvm::SmallString<1024> Buf;
     llvm::raw_svector_ostream Strm(Buf);
-    Strm << Linkage << " int __cxa_atexit(void (*f) (void*), void*, void*);\n"
-         << Linkage << " int atexit(void(*f)()) {"
-            "return __cxa_atexit((void(*)(void*))f, nullptr, (void*)"
-         << m_Executor.get() << "); }\n";
-    Transaction *T = nullptr;
-    declare(Strm.str(), &T);
-    if (llvm::Module* M = T ? T->getModule() : nullptr) {
-      if (const llvm::GlobalValue* GV = M->getNamedValue("atexit"))
-        m_Executor->getPointerToGlobalFromJIT(*GV);
+    const clang::LangOptions& LangOpts = getCI()->getLangOpts();
+    const void* thisP = static_cast<void*>(this);
+
+    // FIXME: gCling should be const so assignemnt is a compile time error.
+    // Currently the name mangling is coming up wrong for the const version
+    // (on OS X at least, so probably Linux too) and the JIT thinks the symbol
+    // is undefined in a child Interpreter.  And speaking of children, should
+    // gCling actually be thisCling, so a child Interpreter can only access
+    // itself? One could use a macro (simillar to __dso_handle) to block
+    // assignemnt and get around the mangling issue.
+    const char* Linkage = LangOpts.CPlusPlus ? "extern \"C\"" : "";
+    if (!NoRuntime && !SyntaxOnly) {
+      if (LangOpts.CPlusPlus) {
+        Strm << "#include \"cling/Interpreter/RuntimeUniverse.h\"\n"
+                "namespace cling { class Interpreter; namespace runtime { "
+                "Interpreter* gCling=(Interpreter*)" << thisP << "; }}\n";
+      } else {
+        Strm << "#include \"cling/Interpreter/CValuePrinter.h\"\n"
+                "void* gCling=(void*)" << thisP << ";\n";
+      }
     }
-  }
 
-  void Interpreter::IncludeCXXRuntime() {
-    // Set up common declarations which are going to be available
-    // only at runtime
-    // Make sure that the universe won't be included to compile time by using
-    // -D __CLING__ as CompilerInstance's arguments
+    // Intercept all atexit calls, as the Interpreter and functions will be long
+    // gone when the -native- versions invoke them.
+    if (!SyntaxOnly) {
+      // While __dso_handle is still overriden in the JIT below,
+      // #define __dso_handle is used to mitigate the following problems:
+      //  1. Type of __dso_handle is void* making assignemnt to it legal
+      //  2. Making it void* const in cling would mean possible type mismatch
+      //  3. Cannot override void* __dso_handle in child Interpreter
+      //  4. On Unix where the symbol actually exists, __dso_handle will be
+      //     linked into the code before the JIT can say otherwise, so:
+      //      [cling] __dso_handle // codegened __dso_handle always printed
+      //      [cling] __cxa_atexit(f, 0, __dso_handle) // seg-fault
+      //  5. Code that actually uses __dso_handle will fail as a declaration is
+      //     needed which is not possible with the macro.
+      //  6. Assuming 4 is sorted out in user code, calling __cxa_atexit through
+      //     atexit below isn't linking to the __dso_handle symbol.
 
-    std::stringstream initializer;
-#ifdef _WIN32
-    // We have to use the #defined __CLING__ on windows first.
-    //FIXME: Find proper fix.
-    initializer << "#ifdef __CLING__ \n#endif\n";
+      Strm << "#define __dso_handle ((void*)" << thisP << ")\n";
+
+      // Use __cxa_atexit to intercept all of the following routines
+      Strm << Linkage << " int __cxa_atexit(void (*f)(void*), void*, void*);\n";
+
+      // C atexit, std::atexit
+      Strm << Linkage << " int atexit(void(*f)()) { "
+           "return __cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); }\n";
+      Globals.push_back("atexit");
+
+      // C++ 11 at_quick_exit, std::at_quick_exit
+      if (LangOpts.CPlusPlus && LangOpts.CPlusPlus11) {
+          Strm << Linkage << " int at_quick_exit(void(*f)()) { "
+           "return __cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); }\n";
+        Globals.push_back("at_quick_exit");
+      }
+
+#if defined(LLVM_ON_WIN32)
+      // Windows specific: _onexit, _onexit_m, __dllonexit
+      Strm << Linkage << " _onexit_t _onexit(_onexit_t f) { "
+         "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;}\n";
+      Globals.push_back("_onexit");
+      Strm << Linkage << " _onexit_t __dllonexit(_onexit_t f, PVFV**, PVFV**) { "
+         "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;}\n";
+      Globals.push_back("__dllonexit");
+ #ifdef _M_CEE
+      Strm << Linkage << " _onexit_t_m _onexit_m(_onexit_t f) { "
+         "__cxa_atexit((void(*)(void*))f, nullptr, __dso_handle); return f;}\n";
+      Globals.push_back("_onexit_m");
+ #endif
 #endif
 
-    initializer << "#include \"cling/Interpreter/RuntimeUniverse.h\"\n";
-
-    if (!isInSyntaxOnlyMode()) {
-      // Set up the gCling variable if it can be used
-      initializer << "namespace cling {namespace runtime { "
-        "cling::Interpreter *gCling=(cling::Interpreter*)"
-        << "0x" << std::hex << (uintptr_t)this << " ;} }";
+      // Override the native symbols now, before anything can be emitted.
+      m_Executor->addSymbol("__cxa_atexit", (void*)&local_cxa_atexit, true);
+      // __dso_handle is inserted for the link phase, as macro is useless then
+      m_Executor->addSymbol("__dso_handle", this, true);
     }
-    declare(initializer.str());
-  }
 
-  void Interpreter::IncludeCRuntime() {
-    // Set up the gCling variable if it can be used
-    std::stringstream initializer;
-    initializer << "void* gCling=(void*)" << (uintptr_t)this << ';';
-    declare(initializer.str());
-    // declare("void setValueNoAlloc(void* vpI, void* vpSVR, void* vpQT);");
-    // declare("void setValueNoAlloc(void* vpI, void* vpV, void* vpQT, float value);");
-    // declare("void setValueNoAlloc(void* vpI, void* vpV, void* vpQT, double value);");
-    // declare("void setValueNoAlloc(void* vpI, void* vpV, void* vpQT, long double value);");
-    // declare("void setValueNoAlloc(void* vpI, void* vpV, void* vpQT, unsigned long long value);");
-    // declare("void setValueNoAlloc(void* vpI, void* vpV, void* vpQT, const void* value);");
-    // declare("void* setValueWithAlloc(void* vpI, void* vpV, void* vpQT);");
+    if (m_Opts.Verbose())
+      llvm::errs() << Strm.str();
 
-    declare("#include \"cling/Interpreter/CValuePrinter.h\"");
+    Transaction *T;
+    declare(Strm.str(), &T);
+    return T;
   }
 
   void Interpreter::AddIncludePaths(llvm::StringRef PathStr, const char* Delm) {
@@ -1248,7 +1297,15 @@ namespace cling {
   }
 
   void Interpreter::AddAtExitFunc(void (*Func) (void*), void* Arg) {
-    m_Executor->AddAtExitFunc(Func, Arg);
+    const Transaction* T = getCurrentTransaction();
+    // Should this be ROOT only?
+    if (!T) {
+      // IncrementalParser::commitTransaction will call
+      // Interpreter::executeTransaction if transaction has no parent.
+      T = getLastTransaction();
+    }
+    assert(T && "No Transaction for Interpreter::AddAtExitFunc");
+    m_Executor->AddAtExitFunc(Func, Arg, T->getModule());
   }
 
   void Interpreter::GenerateAutoloadingMap(llvm::StringRef inFile,

--- a/test/CodeUnloading/AtExit.C
+++ b/test/CodeUnloading/AtExit.C
@@ -1,0 +1,60 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+
+// Test to check functions registered via atexit are intercepted, and __dso_handle
+// is properly overridden in for child interpreters.
+#include <cstdlib>
+#include "cling/Interpreter/Interpreter.h"
+
+
+static void atexit_1() {
+  printf("atexit_1\n");
+}
+static void atexit_2() {
+  printf("atexit_2\n");
+}
+static void atexit_3() {
+  printf("atexit_3\n");
+}
+
+atexit(atexit_1);
+.undo
+// Undoing the registration should call the function
+// CHECK: atexit_1
+
+at_quick_exit(atexit_2);
+.undo
+// Make sure at_quick_exit is resolved correctly (mangling issues on gcc < 5)
+// CHECK-NEXT: atexit_2
+
+atexit(atexit_3);
+
+cling::Interpreter * gChild = 0;
+{
+  const char* kArgV[1] = {"cling"};
+  cling::Interpreter ChildInterp(*gCling, 1, kArgV);
+  gChild = &ChildInterp;
+  ChildInterp.declare("static void atexit_c() { printf(\"atexit_c %d\\n\", gChild==__dso_handle); }");
+  ChildInterp.execute("atexit(atexit_c);");
+}
+// ChildInterp
+// CHECK-NEXT: atexit_c 1
+
+static void atexit_f() {
+  printf("atexit_f %s\n", gCling==__dso_handle ? "true" : "false");
+}
+at_quick_exit(atexit_f);
+
+// expected-no-diagnostics
+.q
+
+// Reversed registration order
+// CHECK-NEXT: atexit_f true
+// CHECK-NEXT: atexit_3


### PR DESCRIPTION
Windows uses atexit to register destructors, and it's usage on other platforms should also be adjusted to run during Interpreter shutdown.