### PR TITLE
Comment redirection test and restore its previous glory.

### DIFF
--- a/test/Prompt/OutputRedirect.C
+++ b/test/Prompt/OutputRedirect.C
@@ -147,11 +147,12 @@ c = 9937
 .&>> $CLING_TMP/bothfile.txt
 var = 999
 //CHECK-REDIRECTBOTH: (int) 999
-.1>$CLING_TMP/anotheroutfile.txt
+
+// Test that exiting in a redirected state will flush properly
+.1> $CLING_TMP/anotheroutfile.txt
 a = 710
 //CHECK-REDIRECTANOTHER: (int) 710
 b = 711
 //CHECK-REDIRECTANOTHER: (int) 711
 c = 712
 //CHECK-REDIRECTANOTHER: (int) 712
-


### PR DESCRIPTION
Testing lack of space in redirection commands already exists and the test that was changed actually tests something else.
Minor quibble, but rather it should fail _only_ for what it was designed to test.
