### PR TITLE
Add 'decl' and 'undo' as predicates to .stats command.

### DIFF
--- a/include/cling/Interpreter/Interpreter.h
+++ b/include/cling/Interpreter/Interpreter.h
@@ -409,6 +409,13 @@ namespace cling {
     ///
     void DumpIncludePath(llvm::raw_ostream* S = nullptr);
 
+    ///\brief Dump various internal data.
+    ///
+    ///\param[in] what - which data to dump. 'undo', 'ast', 'asttree'
+    ///\param[in] filter - optional argument to filter data with.
+    ///
+    void dump(llvm::StringRef what, llvm::StringRef filter);
+
     ///\brief Store the interpreter state in files
     /// Store the AST, the included files and the lookup tables
     ///

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -38,6 +38,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/CodeGen/ModuleBuilder.h"
+#include "clang/Frontend/ASTConsumers.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Frontend/Utils.h"
 #include "clang/Lex/Preprocessor.h"
@@ -441,7 +442,12 @@ namespace cling {
   // FIXME: Add stream argument and move DumpIncludePath path here.
   void Interpreter::dump(llvm::StringRef what, llvm::StringRef filter) {
     llvm::raw_ostream &where = cling::log();
-    if (what.equals("ast"))
+    if (what.equals("asttree")) {
+      std::unique_ptr<clang::ASTConsumer> printer =
+          clang::CreateASTDumper(filter, true  /*DumpDecls*/,
+                                         false /*DumpLookups*/ );
+      printer->HandleTranslationUnit(getSema().getASTContext());
+    } else if (what.equals("ast"))
       getSema().getASTContext().PrintStats();
     else if (what.equals("decl"))
       ClangInternalState::printLookupTables(where, getSema().getASTContext());

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -438,6 +438,17 @@ namespace cling {
                             true /*withSystem*/, true /*withFlags*/);
   }
 
+  // FIXME: Add stream argument and move DumpIncludePath path here.
+  void Interpreter::dump(llvm::StringRef what, llvm::StringRef filter) {
+    llvm::raw_ostream &where = cling::log();
+    if (what.equals("ast"))
+      getSema().getASTContext().PrintStats();
+    else if (what.equals("decl"))
+      ClangInternalState::printLookupTables(where, getSema().getASTContext());
+    else if (what.equals("undo"))
+      m_IncrParser->printTransactionStructure();
+  }
+
   void Interpreter::storeInterpreterState(const std::string& name) const {
     // This may induce deserialization
     PushTransactionRAII RAII(this);

--- a/lib/MetaProcessor/MetaParser.cpp
+++ b/lib/MetaProcessor/MetaParser.cpp
@@ -463,9 +463,12 @@ namespace cling {
       skipWhitespace();
       if (!getCurTok().is(tok::ident))
         return false; // FIXME: Issue proper diagnostics
-      std::string ident = getCurTok().getIdent();
+      llvm::StringRef what = getCurTok().getIdent();
       consumeToken();
-      m_Actions->actOnstatsCommand(ident);
+      skipWhitespace();
+      const Token& next = getCurTok();
+      m_Actions->actOnstatsCommand(what, next.is(tok::ident)
+                                         ? next.getIdent() : llvm::StringRef());
       return true;
     }
     return false;

--- a/lib/MetaProcessor/MetaSema.cpp
+++ b/lib/MetaProcessor/MetaSema.cpp
@@ -360,6 +360,7 @@ namespace cling {
       "\n"
       "   " << metaString << "stats [name]\t\t- Show stats for internal data structures\n"
                              "\t\t\t\t  'ast'  abstract syntax tree stats\n"
+                             "\t\t\t\t  'asttree [filter]'  abstract syntax tree layout\n"
                              "\t\t\t\t  'decl' dump ast declarations\n"
                              "\t\t\t\t  'undo' show undo stack\n"
       "\n"

--- a/lib/MetaProcessor/MetaSema.cpp
+++ b/lib/MetaProcessor/MetaSema.cpp
@@ -17,8 +17,6 @@
 #include "cling/Interpreter/Value.h"
 #include "cling/MetaProcessor/MetaProcessor.h"
 
-#include "../lib/Interpreter/IncrementalParser.h"
-
 #include "clang/AST/ASTContext.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Frontend/CompilerInstance.h"
@@ -287,10 +285,9 @@ namespace cling {
     m_Interpreter.compareInterpreterState(name);
   }
 
-  void MetaSema::actOnstatsCommand(llvm::StringRef name) const {
-    if (name.equals("ast")) {
-      m_Interpreter.getCI()->getSema().getASTContext().PrintStats();
-    }
+  void MetaSema::actOnstatsCommand(llvm::StringRef name,
+                                   llvm::StringRef args) const {
+    m_Interpreter.dump(name, args);
   }
 
   void MetaSema::actOndynamicExtensionsCommand(SwitchMode mode/* = kToggle*/)
@@ -361,8 +358,10 @@ namespace cling {
       "   " << metaString << "compareState <filename>\t- Compare the interpreter's state with the one"
                              "\n\t\t\t\t  saved in a given file\n"
       "\n"
-      "   " << metaString << "stats [name]\t\t- Show stats for various internal data"
-                             "\n\t\t\t\t  structures (only 'ast' for the time being)\n"
+      "   " << metaString << "stats [name]\t\t- Show stats for internal data structures\n"
+                             "\t\t\t\t  'ast'  abstract syntax tree stats\n"
+                             "\t\t\t\t  'decl' dump ast declarations\n"
+                             "\t\t\t\t  'undo' show undo stack\n"
       "\n"
       "   " << metaString << "help\t\t\t- Shows this information\n"
       "\n"

--- a/lib/MetaProcessor/MetaSema.h
+++ b/lib/MetaProcessor/MetaSema.h
@@ -169,8 +169,10 @@ namespace cling {
     ///\brief Show stats for various internal data structures.
     ///
     ///\param[in] name - Name of the structure.
+    ///\param[in] filter - Optional predicate for filtering displayed stats.
     ///
-    void actOnstatsCommand(llvm::StringRef name) const;
+    void actOnstatsCommand(llvm::StringRef name,
+                           llvm::StringRef filter = llvm::StringRef()) const;
 
     ///\brief Switches on/off the experimental dynamic extensions (dynamic
     /// scopes) and late binding.


### PR DESCRIPTION
Useful for debugging & required for tests in subsequent PRs.