### PR TITLE
Fix assertion test for null terminated string.

### DIFF
--- a/lib/Utils/PlatformPosix.cpp
+++ b/lib/Utils/PlatformPosix.cpp
@@ -209,7 +209,7 @@ std::string Demangle(const std::string& Symbol) {
   int status = 0;
   size_t len;
   AutoFree af(abi::__cxa_demangle(Symbol.c_str(), 0, &len, &status));
-  assert(((len && af.Str[len-1]==0) || status != 0) && "Not null terminated");
+  assert((status != 0 || (len && af.Str[len-1]==0)) && "Not null terminated");
   return status == 0 ? std::string(af.Str, len-1) : std::string();
 }
 


### PR DESCRIPTION
Logic ordering was fatally bad.