### PR TITLE
Windows: Add compiler flags to ignore linkage spec errors.

### DIFF
--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -203,6 +203,16 @@ namespace {
       }
 #endif
 
+      // Windows headers use '__declspec(dllexport) __cdecl' for most funcs
+      // causing a lot of warnings for different redeclarations (eg. coming from
+      // the test suite).
+      // Do not warn about such cases.
+      sArguments.addArgument("-Wno-dll-attribute-on-redeclaration");
+      sArguments.addArgument("-Wno-inconsistent-dllimport");
+      //sArguments.addArgument("-Wno-ignored-attributes");
+      //sArguments.addArgument("-Wno-dllimport-static-field-def");
+      //sArguments.addArgument("-Wno-microsoft-template");
+
 #else // _MSC_VER
 
       // Skip LLVM_CXX execution if -nostdinc++ was provided.


### PR DESCRIPTION
So things like `extern "C" int printf(const char*, ...)` work on Windows.
For the tests and so users won't have to declare imported functions with `declspec(dllimport)`