### PR TITLE
Additional tweaks for recent commits.

### DIFF
--- a/include/cling/Interpreter/Value.h
+++ b/include/cling/Interpreter/Value.h
@@ -11,6 +11,7 @@
 #define CLING_VALUE_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include <type_traits>
 
 namespace llvm {
@@ -137,7 +138,7 @@ namespace cling {
           return (T) V.getAs<long double>();
         case kPointerType:
         case kManagedAllocation:
-          return (T) (size_t) V.getAs<void*>();
+          return (T) (uintptr_t) V.getAs<void*>();
         case kUnsupportedType:
           V.AssertOnUnsupportedTypeCast();
         }
@@ -151,7 +152,7 @@ namespace cling {
         EStorageType storageType = V.getStorageType();
         if (storageType == kPointerType
             || storageType == kManagedAllocation)
-          return (T*) (size_t) V.getAs<void*>();
+          return (T*) (uintptr_t) V.getAs<void*>();
         V.AssertOnUnsupportedTypeCast();
         return 0;
       }

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -679,13 +679,13 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
                                  bool /*Complain*/,
                                  bool /*AllowCompatibleDifferences*/) override {
           *m_Invocation.getLangOpts() = LangOpts;
-          return true;
+          return false;
         }
         bool ReadTargetOptions(const TargetOptions &TargetOpts,
                                bool /*Complain*/,
                                bool /*AllowCompatibleDifferences*/) override {
           m_Invocation.getTargetOpts() = TargetOpts;
-          return true;
+          return false;
         }
         bool ReadPreprocessorOptions(const PreprocessorOptions &PPOpts,
                                      bool /*Complain*/,
@@ -695,7 +695,7 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
           insertBehind(myPP.Macros, PPOpts.Macros);
           insertBehind(myPP.Includes, PPOpts.Includes);
           insertBehind(myPP.MacroIncludes, PPOpts.MacroIncludes);
-          return true;
+          return false;
         }
       };
       PCHListener listener(*Invocation);

--- a/lib/Interpreter/IncrementalExecutor.cpp
+++ b/lib/Interpreter/IncrementalExecutor.cpp
@@ -154,9 +154,7 @@ void* IncrementalExecutor::HandleMissingFunction(const std::string& mangled_name
     //             << mangled_name << "'!\n";
   }
 
-  // Avoid "ISO C++ forbids casting between pointer-to-function and
-  // pointer-to-object":
-  return (void*)reinterpret_cast<size_t>(unresolvedSymbol);
+  return utils::FunctionToVoidPtr(&unresolvedSymbol);
 }
 
 void* IncrementalExecutor::NotifyLazyFunctionCreators(const std::string& mangled_name)

--- a/lib/Interpreter/IncrementalParser.cpp
+++ b/lib/Interpreter/IncrementalParser.cpp
@@ -89,9 +89,11 @@ namespace {
     const clang::Preprocessor& PP = CI->getPreprocessor();
     const clang::Token* Tok = getMacroToken(PP, CLING_CXXABI_NAME);
     if (Tok && Tok->isLiteral()) {
+      // Tok::getLiteralData can fail even if Tok::isLiteral is true!
+      SmallString<64> Buffer;
+      CurABI = PP.getSpelling(*Tok, Buffer);
       // Strip any quotation marks.
-      CurABI = llvm::StringRef(Tok->getLiteralData(),
-                               Tok->getLength()).trim("\"");
+      CurABI = CurABI.trim("\"");
       if (CurABI.equals(CLING_CXXABI_VERS))
         return true;
     }

--- a/lib/Interpreter/Value.cpp
+++ b/lib/Interpreter/Value.cpp
@@ -232,8 +232,9 @@ namespace cling {
   } // end namespace valuePrinterInternal
 
   void Value::print(llvm::raw_ostream& Out, bool Escape) const {
-    // Get the default type string representation
-    Out << cling::valuePrinterInternal::printTypeInternal(*this) << ' ';
+    // Save the default type string representation so output can occur as one
+    // operation (calling printValueInternal below may write to stderr).
+    const std::string Type = valuePrinterInternal::printTypeInternal(*this);
 
     // Get the value string representation, by printValue() method overloading
     const std::string Val = cling::valuePrinterInternal::printValueInternal(*this);
@@ -249,14 +250,15 @@ namespace cling {
         case '\"':
           if (N > 2 && Data[N-1] == '\"') {
             // Drop the terminating " so Utf-8 errors can be detected ("\xeA")
-            Out << utils::utf8::EscapeSequence().encode(Data, N-1) << "\"\n";
+            Out << Type << ' '
+                << utils::utf8::EscapeSequence().encode(Data, N-1) << "\"\n";
             return;
           }
         default:
           break;
       }
     }
-    Out << Val << '\n';
+    Out << Type << ' ' << Val << '\n';
   }
 
   void Value::dump(bool Escape) const {

--- a/test/CodeGeneration/Inline.C
+++ b/test/CodeGeneration/Inline.C
@@ -1,0 +1,57 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN:cat %s |  %cling -I %S -Xclang -verify 2>&1 | FileCheck -allow-empty %s
+// Test testInline
+
+// ROOT-8283
+
+inline int localInline() { return 5; }
+localInline();
+localInline();
+.undo
+.undo
+localInline();
+
+extern "C" int printf(const char*, ...);
+
+#include "Inline.h"
+testInline(101)
+// CHECK: 101
+.undo
+
+testInline(201)
+// CHECK-NEXT: 201
+testInline(202)
+// CHECK-NEXT: 202
+testInline(203)
+// CHECK-NEXT: 203
+.undo  // testInline()
+.undo  // testInline()
+.undo  // testInline()
+
+testInline(301)
+// CHECK-NEXT: 301
+.undo  // testInline()
+
+testInline(testInlineRet(301))
+// CHECK-NEXT: 602
+.undo  // testInline()
+
+testInline(testInlineRet(401))
+// CHECK-NEXT: 802
+.undo  // testInline()
+
+.undo  // #include "Inline.h"
+testInline(501) // expected-error {{use of undeclared identifier 'testInline'}}
+
+#include "Inline.h"
+testInline(testInlineRet(606))
+// CHECK-NEXT: 1212
+
+.q

--- a/test/CodeGeneration/Inline.h
+++ b/test/CodeGeneration/Inline.h
@@ -1,0 +1,4 @@
+
+inline void testInline(int arg) { printf("%d\n", arg); }
+inline int testInlineRet(int arg) { return arg+arg; }
+


### PR DESCRIPTION
Use utils::FunctionToVoidPtr.
Use uintptr_t rather than size_t when casting pointer to integer.
Add test for ROOT-8283.
Fix errors from interrupting Value::print's string output in terminals.

