### PR TITLE
Fix problems related to new FilteringDiagConsumer.

### DIFF
--- a/include/cling/Utils/Diagnostics.h
+++ b/include/cling/Utils/Diagnostics.h
@@ -1,0 +1,120 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author: Roman Zulak
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#ifndef CLING_UTILS_DIAGNOSTICS_H
+#define CLING_UTILS_DIAGNOSTICS_H
+
+#include "clang/Basic/Diagnostic.h"
+
+namespace cling {
+namespace utils {
+
+    ///\brief Temporarily replace the DiagnosticConsumer in a DiagnosticsEngine
+    ///
+    class ReplaceDiagnostics {
+    protected:
+      clang::DiagnosticsEngine& m_Diags;
+      clang::DiagnosticConsumer& m_PrevClient;
+      const unsigned m_PrevOwn : 1;
+
+    public:
+      ///\brief ReplaceDiagnostics constructor
+      ///
+      ///\param[in] Diags - The DiagnosticsEngine instance to override
+      ///\param[in] Replace - The DiagnosticConsumer to set as the new client
+      ///\param[in] Own - Whether the DiagnosticsEngine owns that client
+      ///
+      ReplaceDiagnostics(clang::DiagnosticsEngine& D,
+                         clang::DiagnosticConsumer& Replace, bool Own);
+
+      ///\brief Temporarily restore the prior DiagnosticConsumer
+      ///
+      ///\param[in] Other - Which DiagnosticConsumer to restore to
+      ///
+      ReplaceDiagnostics(const ReplaceDiagnostics& Other)
+          : ReplaceDiagnostics(Other.m_Diags, Other.m_PrevClient,
+                               Other.m_PrevOwn) {}
+
+      ~ReplaceDiagnostics() { m_Diags.setClient(&m_PrevClient, m_PrevOwn); }
+    };
+
+    ///\brief Temporarily override the DiagnosticConsumer in a DiagnosticsEngine
+    /// Inherits from ReplaceDiagnostics so that forwarding can be done easily
+    ///
+    class DiagnosticsOverride : public clang::DiagnosticConsumer,
+                                public ReplaceDiagnostics {
+    public:
+      ///\brief DiagnosticsOverride constructor
+      ///
+      ///\param[in] Diags - The DiagnosticsEngine instance to override
+      ///\param[in] Own - Should DiagnosticsEngine should delete when done?
+      ///
+      DiagnosticsOverride(clang::DiagnosticsEngine& Diags, bool Own = false)
+          : ReplaceDiagnostics(Diags, *this, Own) {}
+    };
+
+    ///\brief Store all of the errors sent to a DiagnosticsEngine
+    ///
+    class DiagnosticsStore : public DiagnosticsOverride {
+      typedef std::vector<clang::StoredDiagnostic> Storage;
+
+      // Bitfield first in the hopes it can be joined to ReplaceDiagnostics'
+      const unsigned m_Flags : 2;
+      Storage m_Saved;
+
+      void HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
+                            const clang::Diagnostic& Info) override;
+
+    public:
+      ///\brief Store all further diagnostics
+      ///
+      ///\param[in] Diags - The DiagnosticsEngine instance to override
+      ///\param[in] Own - Whether the DiagnosticsEngine owns this instance
+      ///\param[in] Report - Report the collected error on destruction
+      ///\param[in] Reset - Soft reset the DiagnosticsEngine on destruction
+      ///
+      DiagnosticsStore(clang::DiagnosticsEngine& Diags, bool Own,
+                       bool Report = 1, bool Reset = 0);
+
+      ~DiagnosticsStore();
+
+      ///\brief Report the stored diagnostics to the previous DiagnosticConsumer
+      ///
+      ///\param[in] DoReset - Reset stored diagnostics after reporting
+      ///
+      void Report(bool DoReset = true);
+
+      ///\brief Clear the stored diagnostics
+      ///
+      void Reset() {
+        Storage().swap(m_Saved);
+        DiagnosticsOverride::clear();
+      }
+
+      ///\brief STL interface to the stored diagnostics
+      ///
+      typedef Storage::value_type value_type;
+      typedef Storage::iterator iterator;
+      typedef Storage::const_iterator const_iterator;
+
+      const_iterator begin() const { return m_Saved.begin(); }
+      const_iterator end() const { return m_Saved.end(); }
+      iterator begin() { return m_Saved.begin(); }
+      iterator end() { return m_Saved.end(); }
+      size_t size() const { return m_Saved.size(); }
+      bool empty() const { return m_Saved.empty(); }
+      const clang::StoredDiagnostic& operator[](int i) const {
+        return m_Saved[i];
+      }
+    };
+
+} // namespace utils
+} // namespace cling
+
+#endif // CLING_UTILS_DIAGNOSTICS_H

--- a/lib/Interpreter/ExternalInterpreterSource.cpp
+++ b/lib/Interpreter/ExternalInterpreterSource.cpp
@@ -117,11 +117,8 @@ namespace cling {
 
       Diags.setClient(Prev.get(), OwnClient);
       Prev.release();
-#if LLVM_VERSION_MAJOR >= 4
-      // In LLVM 4 the test above still works, but the errors generated are
-      // still propogated...So just reset the Diags.
+      // Already asserted there were no errors to begin with so just reset it.
       Diags.Reset(true);
-#endif
 #endif
       return;
     }

--- a/lib/Interpreter/IncrementalParser.h
+++ b/lib/Interpreter/IncrementalParser.h
@@ -28,6 +28,7 @@ namespace llvm {
 namespace clang {
   class CodeGenerator;
   class CompilerInstance;
+  class DiagnosticConsumer;
   class Decl;
   class FileID;
   class Parser;
@@ -87,6 +88,10 @@ namespace cling {
     ///\brief Pool of reusable block-allocated transactions.
     ///
     std::unique_ptr<TransactionPool> m_TransactionPool;
+
+    ///\brief DiagnosticConsumer instance
+    ///
+    std::unique_ptr<clang::DiagnosticConsumer> m_DiagConsumer;
 
   public:
     enum EParseResult {

--- a/lib/Utils/CMakeLists.txt
+++ b/lib/Utils/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 
 add_cling_library(clingUtils OBJECT
   AST.cpp
+  Diagnostics.cpp
   ParserStateRAII.cpp
   Output.cpp
   Paths.cpp

--- a/lib/Utils/Diagnostics.cpp
+++ b/lib/Utils/Diagnostics.cpp
@@ -1,0 +1,65 @@
+//--------------------------------------------------------------------*- C++ -*-
+// CLING - the C++ LLVM-based InterpreterG :)
+// author: Roman Zulak
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+#include "cling/Utils/Diagnostics.h"
+
+namespace cling {
+namespace utils {
+
+ReplaceDiagnostics::ReplaceDiagnostics(clang::DiagnosticsEngine& D,
+                         clang::DiagnosticConsumer& Replace, bool Own) :
+  m_Diags(D), m_PrevClient(*D.getClient()), m_PrevOwn(D.ownsClient()) {
+  // DiagnosticsEngine requires a client to be set, so guarantee
+  // m_PrevClient is not null by it being a reference.
+  assert(D.getClient() && "DiagnosticConsumer not set");
+  // Take the std::unique_ptr and release it, we have the raw one
+  D.takeClient().release();
+  // Set the new client / consumer
+  D.setClient(&Replace, Own);
+}
+
+namespace {
+  enum {
+      kReport = 1,  ///< Report errors on destruction
+      kReset  = 2,  ///< Reset DiagnosticsEngine on destruction
+  };
+}
+
+DiagnosticsStore::DiagnosticsStore(clang::DiagnosticsEngine& Diags, bool Own,
+                                    bool Report, bool Reset) :
+  DiagnosticsOverride(Diags, Own),
+  m_Flags(Report | (Reset << 1)) {
+}
+
+DiagnosticsStore::~DiagnosticsStore() {
+  if (m_Flags & kReport)
+    Report();
+  if (m_Flags & kReset)
+    m_Diags.Reset(true);
+}
+
+void
+DiagnosticsStore::HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
+                                   const clang::Diagnostic& Info) {
+  m_Saved.emplace_back(clang::StoredDiagnostic(Level, Info));
+  DiagnosticConsumer::HandleDiagnostic(Level, Info);
+}
+
+void
+DiagnosticsStore::Report(bool DoReset) {
+  // Don't wan't to report to ourself!
+  ReplaceDiagnostics Tmp(*this);
+  for (const clang::StoredDiagnostic& Diag : m_Saved)
+    m_Diags.Report(Diag);
+  if (DoReset)
+    Reset();
+}
+
+} // namespace utils
+} // namespace cling

--- a/test/ErrorRecovery/Diagnostics.C
+++ b/test/ErrorRecovery/Diagnostics.C
@@ -1,0 +1,31 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %built_cling -fno-rtti -Xclang -verify 2>&1 | FileCheck %s
+
+// Test that user can override the DiagnosicsClient without error
+
+#include <cling/Interpreter/Interpreter.h>
+#include <cling/Utils/Diagnostics.h>
+#include <cling/Utils/Output.h>
+#include <clang/Frontend/CompilerInstance.h>
+
+using namespace cling::utils;
+DiagnosticsStore LC(gCling->getCI()->getDiagnostics(), false);
+gCling->echo("error");
+
+// When preprocessed out is supported, test that reporting works too.
+// LC.Report();
+
+for (const auto& D : LC) {
+  cling::outs() << "STORED <" << D.getMessage() << ">\n";
+}
+// CHECK: STORED <use of undeclared identifier 'error'>
+
+// expected-no-diagnostics
+.q


### PR DESCRIPTION
There are a few problems I've run into with the new `FilteringDiagConsumer`:
1. Misuses `DiagnosticsEngine` API by calling `DiagnosticsEngine::takeClient`. This call only returns the prior `DiagnosticConsumer ` when is it is owned by the `DiagnosticsEngine `  (i.e. can be NULL). Something it or it's base class cannot handle.
2. `IncrementalParser::ParseInternal` assumes the current consumer will always be a `FilteringDiagConsumer ` and blindly casts it to one, crashing if the consumer is set at runtime by a client.

This provides helper classes to abstract the _overly subtle_  needs of  `DiagnosticsEngine ` when temporarily replacing or forwarding a consumer, and another class to easily intercept/store errors.