### PR TITLE
Windows: Temporary fix for crash in std::string destruction

### DIFF
--- a/include/cling/Interpreter/RuntimePrintValue.h
+++ b/include/cling/Interpreter/RuntimePrintValue.h
@@ -20,6 +20,11 @@
 
 namespace cling {
 
+#ifdef _WIN32
+  // FIXME: Interpreter currently needs to construct the first std::string
+  namespace horriblehack { static const std::string kRealyyBad; }
+#endif
+
   class Value;
 
   // General fallback - prints the address


### PR DESCRIPTION
This is truly ugly but allows 28 tests to pass.

The problem is that if the first std::string is constructed internally by the managed allocation of ValuePrinter then it's destruction will crash. I have yet to understand why exactly. But I have a suspicion it is either related to the JIT linking layer or there is some static variable that is messing things up.