### PR TITLE
Fix ExternC test on Linux.

### DIFF
--- a/test/CodeUnloading/ExternC.C
+++ b/test/CodeUnloading/ExternC.C
@@ -23,7 +23,6 @@ extern "C" int printf(const char*,...);
 extern "C" {
   int printf(const char*,...);
   int abs(int);
-  int atexit(void (*)(void));
   double atof(const char *);
   void free(void* ptr);
 }


### PR DESCRIPTION
From the other thread:

Ok, the problem seems to be line 10 of test/CodeUnloading/ExternC.C
int atexit(void (*)(void));
Removing that line fixes it here.

On Linux atexit is really atexit nothrow() which causes an error in compilation. This messes up the test as one Transaction fails, and the amount of .undo submitted later is one more than it should be (i.e. it unwinds cling to 0 transactions instead of the first).

I'll do a PR, but it might be quicker for you just to edit, as I want to test/make sure #94 fixes the crash because of this error.