### PR TITLE
added a command line flag and associated code to support dumb terminals

### DIFF
--- a/include/cling/Interpreter/ClingOptions.inc
+++ b/include/cling/Interpreter/ClingOptions.inc
@@ -18,6 +18,8 @@ PREFIX(prefix_2, {"--" COMMA 0})
 
 OPTION(prefix_0, "<input>", INPUT, Input, INVALID, INVALID, 0, 0, 0, 0, 0)
 OPTION(prefix_0, "<unknown>", UNKNOWN, Unknown, INVALID, INVALID, 0, 0, 0, 0, 0)
+OPTION(prefix_2, "dumbterm", _dumbterm, Flag, INVALID, INVALID, 0, 0, 0,
+       "Using a dumb terminal", 0)
 OPTION(prefix_2, "errorout", _errorout, Flag, INVALID, INVALID, 0, 0, 0,
        "Do not recover from input errors", 0)
 OPTION(prefix_3, "help", help, Flag, INVALID, INVALID, 0, 0, 0,

--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -66,6 +66,7 @@ namespace cling {
 
     bool ErrorOut;
     bool NoLogo;
+    bool DumbTerm;
     bool ShowVersion;
     bool Help;
     bool Verbose() const { return CompilerOpts.Verbose; }

--- a/lib/Interpreter/InvocationOptions.cpp
+++ b/lib/Interpreter/InvocationOptions.cpp
@@ -63,6 +63,7 @@ namespace {
                                InputArgList& Args) {
     Opts.ErrorOut = Args.hasArg(OPT__errorout);
     Opts.NoLogo = Args.hasArg(OPT__nologo);
+    Opts.DumbTerm = Args.hasArg(OPT__dumbterm);
     Opts.ShowVersion = Args.hasArg(OPT_version);
     Opts.Help = Args.hasArg(OPT_help);
     if (Arg* MetaStringArg = Args.getLastArg(OPT__metastr, OPT__metastr_EQ)) {
@@ -136,7 +137,7 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
 }
 
 InvocationOptions::InvocationOptions(int argc, const char* const* argv) :
-  MetaString("."), ErrorOut(false), NoLogo(false), ShowVersion(false),
+  MetaString("."), ErrorOut(false), NoLogo(false), DumbTerm(false), ShowVersion(false),
   Help(false) {
 
   ArrayRef<const char *> ArgStrings(argv, argv + argc);

--- a/lib/UserInterface/UserInterface.cpp
+++ b/lib/UserInterface/UserInterface.cpp
@@ -98,6 +98,9 @@ namespace cling {
     UITabCompletion* Completion =
                       new UITabCompletion(m_MetaProcessor->getInterpreter());
     TI.SetCompletion(Completion);
+    if (m_MetaProcessor->getInterpreter().getOptions().DumbTerm) {
+        TI.SetIsDumbTerm(true);
+    }
 
     std::string Line;
     std::string Prompt("[cling]$ ");

--- a/lib/UserInterface/textinput/TextInput.cpp
+++ b/lib/UserInterface/textinput/TextInput.cpp
@@ -31,6 +31,7 @@
 namespace textinput {
   TextInput::TextInput(Reader& reader, Display& display,
                        const char* HistFile /* = 0 */):
+  fIsDumbTerm(false),
   fMasked(false),
   fAutoHistAdd(true),
   fLastKey(0),
@@ -61,9 +62,11 @@ namespace textinput {
     }
     fContext->GetEditor()->ResetText();
 
-    // Signal displays that the input got taken.
-    std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
-             std::mem_fun(&Display::NotifyResetInput));
+    if (!fIsDumbTerm) {
+        // Signal displays that the input got taken.
+        std::for_each(fContext->GetDisplays().begin(), fContext->GetDisplays().end(),
+                      std::mem_fun(&Display::NotifyResetInput));
+    }
 
     ReleaseInputOutput();
 
@@ -124,7 +127,9 @@ namespace textinput {
              || (*iR)->HaveBufferedInput()) {
         if ((*iR)->ReadInput(nRead, in)) {
           ProcessNewInput(in, R);
-          DisplayNewInput(R, OldCursorPos);
+          if (!IsDumbTerm()) {
+              DisplayNewInput(R, OldCursorPos);
+          }
           if (fLastReadResult == kRREOF
               || fLastReadResult == kRRReadEOLDelimiter)
             break;

--- a/lib/UserInterface/textinput/TextInput.h
+++ b/lib/UserInterface/textinput/TextInput.h
@@ -88,6 +88,13 @@ namespace textinput {
     void EnableAutoHistAdd(bool enable = true) { fAutoHistAdd = enable; }
     void AddHistoryLine(const char* line);
 
+    // Dumb terminal getter and setter
+    bool IsDumbTerm() const {return fIsDumbTerm;}
+    void SetIsDumbTerm(bool isDumbTerm) { fIsDumbTerm = isDumbTerm; }
+
+  protected:
+    bool fIsDumbTerm; // whether this is a dumb terminal or not
+
   private:
     void EmitSignal(char c, EditorRange& r);
     void ProcessNewInput(const InputData& in, EditorRange& r);


### PR DESCRIPTION
Emacs and other subshells that manage their own input result in noisy output at the cling interpreter.  More specifically, entering "int x = 5;" at the prompt will result in the interpreter recursively printing the input adding one character each time - "iinintint int xint x int x =int x = int x = 5int x = 5;int x = 5;".   This seems to be because cling cannot control the cursor location in dumb terminals and therefore cannot update the text at the prompt with each new character.  It instead prints each update.

Subshells such as those in emacs, manage user input until a newline and then send the input to the underlying process.  The output of the underlying process is echoed in the subshell.  Because this shell is managed and cling does not have as much control, this results in noisy output.

This pull request adds a command line flag to indicate whether this is a dumb terminal.  If so, it does not update the content of the terminal on each input character and does not add a newline (since the dumb terminal would add its own).  This is implemented as a member variable of the TextInput class.