### PR TITLE
Add ability to control cling output streams colorization.

### DIFF
--- a/include/cling/Utils/Output.h
+++ b/include/cling/Utils/Output.h
@@ -16,6 +16,19 @@
 
 namespace cling {
   namespace utils {
+    ///\brief setup colorization of the output streams below
+    ///
+    ///\param[in] Which - Ored value of streams to colorize: 0 means none.
+    /// 0 = Don't colorize any output
+    /// 1 = Colorize cling::outs
+    /// 2 = Colorize cling::errs
+    /// 4 = Colorize cling::log (currently always the same as cling::errs)
+    /// 8 = Colorize based on whether stdout/err are dsiplayed on tty or not.
+    ///
+    ///\returns Whether any output stream was colorized.
+    ///
+    bool ColorizeOutput(unsigned Which = 8);
+    
     ///\brief The 'stdout' stream. llvm::raw_ostream wrapper of std::cout
     ///
     llvm::raw_ostream& outs();

--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -773,6 +773,9 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     CI->setInvocation(InvocationPtr.get());
     InvocationPtr.release();
     CI->setDiagnostics(Diags.get()); // Diags is ref-counted
+    if (!OnlyLex)
+      CI->getDiagnosticOpts().ShowColors = cling::utils::ColorizeOutput();
+
 
     // Copied from CompilerInstance::createDiagnostics:
     // Chain in -verify checker, if requested.


### PR DESCRIPTION
Don't know if this never was or was lost during the move to cling::errs() etc, but it's very nice.
Default to colorize when running in a terminal.