### PR TITLE
Force __cxa_demangle to null terminate its output.

### DIFF
--- a/lib/Utils/PlatformPosix.cpp
+++ b/lib/Utils/PlatformPosix.cpp
@@ -207,10 +207,10 @@ std::string Demangle(const std::string& Symbol) {
     ~AutoFree() { ::free(Str); };
   };
   int status = 0;
-  size_t len;
-  AutoFree af(abi::__cxa_demangle(Symbol.c_str(), 0, &len, &status));
-  assert((status != 0 || (len && af.Str[len-1]==0)) && "Not null terminated");
-  return status == 0 ? std::string(af.Str, len-1) : std::string();
+  // Some implementations of __cxa_demangle are giving back length of allocation
+  // Passing NULL for length seems to guarantee null termination.
+  AutoFree af(abi::__cxa_demangle(Symbol.c_str(), NULL, NULL, &status));
+  return status == 0 ? std::string(af.Str) : std::string();
 }
 
 } // namespace platform


### PR DESCRIPTION
Turns out some older gcc implementation either do not honor or were written before the docs for `__cxa_demangle`, and they return the size of the buffer allocated not the string length.

