### PR TITLE
Fix returning to stdout after redirection.

### DIFF
--- a/lib/MetaProcessor/MetaProcessor.cpp
+++ b/lib/MetaProcessor/MetaProcessor.cpp
@@ -135,22 +135,18 @@ namespace cling {
     }
 
     // Restore stdstream from backup and close the backup
-    void close(int oldfd, int newfd) {
+    void close(int &oldfd, int newfd) {
       assert((newfd == STDOUT_FILENO || newfd == STDERR_FILENO) && "Not std FD");
       assert(oldfd == m_Bak[newfd == STDERR_FILENO] && "Not backup FD");
       if (oldfd != kInvalidFD) {
         dup2(oldfd, newfd, "RedirectOutput::close");
         ::close(oldfd);
+        oldfd = kInvalidFD;
       }
     }
 
-    void reset(int oldfd, int newfd, FILE *F) {
-      fflush(F);
-      dup2(oldfd, newfd, "RedirectOutput::reset");
-    }
-
     int restore(int FD, FILE *F, MetaProcessor::RedirectionScope Flag,
-                int bakFD) {
+                int &bakFD) {
       // If no backup, we have never redirected the file, so nothing to restore
       if (bakFD != kInvalidFD) {
         // Find the last redirect for the scope, and restore redirection to it
@@ -165,9 +161,10 @@ namespace cling {
         }
 
         // No redirection for this scope, restore to backup
-        reset(bakFD, FD, F);
+        fflush(F);
+        close(bakFD, FD);
       }
-      return bakFD;
+      return kInvalidFD;
     }
 
   public:
@@ -187,6 +184,12 @@ namespace cling {
       // State 2, was tty to begin with, then redirected to stderr and back.
       if (m_TTY == 2)
         ::freopen("CON", "w", stdout);
+#else
+      // If redirection took place without writing anything to the terminal
+      // beforehand (--nologo) then the dup2 relinking stdout will have caused
+      // it to be re-opened without line buffering.
+      if (m_TTY)
+        ::setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
 #endif
     }
 
@@ -254,10 +257,12 @@ namespace cling {
         return;
 
       if (toBackup) {
-        if (m_Bak[0] != kInvalidFD)
-          reset(m_Bak[0], STDOUT_FILENO, stdout);
+        if (m_Bak[0] != kInvalidFD) {
+          fflush(stdout);
+          dup2(m_Bak[0], STDOUT_FILENO, "RedirectOutput::resetStdOut");
+        }
       } else if (m_CurStdOut != kInvalidFD)
-        dup2(m_CurStdOut, STDOUT_FILENO, "RedirectOutput::reset");
+        dup2(m_CurStdOut, STDOUT_FILENO, "RedirectOutput::resetStdOut");
     }
 
     bool empty() const {

--- a/lib/UserInterface/textinput/TerminalDisplayUnix.cpp
+++ b/lib/UserInterface/textinput/TerminalDisplayUnix.cpp
@@ -124,8 +124,8 @@ namespace textinput {
     }
   }
 
-// Don't rely on flushing here.
-#define SYNC_OUT(fd) if (fd==STDOUT_FILENO) { ::fflush(stdout); }
+// Don't rely on flushing here. REALLY, try to fix it elsewhere!
+#define SYNC_OUT(fd) /*if (fd==STDOUT_FILENO) { ::fflush(stdout); } }*/
 
   TerminalDisplayUnix::~TerminalDisplayUnix() {
     Detach();


### PR DESCRIPTION
Calling dup2 to get back to STDOUT_FILENO will reopen stdout without line buffering if no output had been written before the redirect occurred.