### PR TITLE
Fixes for Windows test.

### DIFF
--- a/lib/Interpreter/CIFactory.cpp
+++ b/lib/Interpreter/CIFactory.cpp
@@ -529,6 +529,8 @@ static void stringifyPreprocSetting(PreprocessorOptions& PPOpts,
     PPOpts.addMacroDef("__CLING__clang__=" ClingStringify(__clang__));
 #elif defined(__GNUC__)
     PPOpts.addMacroDef("__CLING__GNUC__=" ClingStringify(__GNUC__));
+#elif defined(_MSC_VER)
+    PPOpts.addMacroDef("__CLING__MSVC__=" ClingStringify(_MSC_VER));
 #endif
 
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html

--- a/test/Driver/E.C
+++ b/test/Driver/E.C
@@ -6,10 +6,10 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-// RUN: %cling -dM -E -xc++ /dev/null | grep CLING | FileCheck %s
+// RUN: echo "" | %cling -dM -E -xc++ -std=c++11 | grep CLING | FileCheck %s
 
 // CHECK: #define __CLING__ 1
 // CHECK: #define __CLING__CXX11 1
-// CHECK: #define __CLING__{{GNUC|clang}}
+// CHECK: #define __CLING__{{GNUC|clang|MSVC}}
 
 .q

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -42,7 +42,7 @@ if(MSVC)
   set_target_properties(cling
     PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
   set_property(TARGET cling APPEND_STRING PROPERTY LINK_FLAGS
-    " /EXPORT:??_7type_info@@6B@ /EXPORT:?__type_info_root_node@@3U__type_info_node@@A")
+    " /EXPORT:??_7type_info@@6B@ /EXPORT:?__type_info_root_node@@3U__type_info_node@@A /EXPORT:_Init_thread_abort /EXPORT:_Init_thread_epoch /EXPORT:_Init_thread_footer /EXPORT:_Init_thread_header /EXPORT:_tls_index /EXPORT:?getAsString@QualType@clang@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBVType@2@VQualifiers@2@@Z /EXPORT:?print@Decl@clang@@QEBAXAEAVraw_ostream@llvm@@I_N@Z /EXPORT:??6raw_ostream@llvm@@QEAAAEAV01@PEBX@Z /EXPORT:?getQualifiedNameAsString@NamedDecl@clang@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ /EXPORT:?insert_imp_big@SmallPtrSetImplBase@llvm@@AEAA?AU?$pair@PEBQEBX_N@std@@PEBX@Z /EXPORT:?getAsStringInternal@QualType@clang@@SAXPEBVType@2@VQualifiers@2@AEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUPrintingPolicy@2@@Z /EXPORT:?_Facet_Register@std@@YAXPEAV_Facet_base@1@@Z /EXPORT:?decls_begin@DeclContext@clang@@QEBA?AVdecl_iterator@12@XZ /EXPORT:?nothrow@std@@3Unothrow_t@1@B /EXPORT:?field_begin@RecordDecl@clang@@QEBA?AV?$specific_decl_iterator@VFieldDecl@clang@@@DeclContext@2@XZ /EXPORT:?errs@llvm@@YAAEAVraw_ostream@1@XZ /EXPORT:?grow_pod@SmallVectorBase@llvm@@IEAAXPEAX_K1@Z /EXPORT:?write@raw_ostream@llvm@@QEAAAEAV12@E@Z")
 endif(MSVC)
 
 target_link_libraries(cling


### PR DESCRIPTION
Whether these functions aren't being exported because of CMake, the build configuration, or MSVC thinking they shouldn't be is unknown to me.