### PR TITLE
Add -noruntime flag to force cling to load minimum decls at startup

### DIFF
--- a/include/cling/Interpreter/ClingOptions.inc
+++ b/include/cling/Interpreter/ClingOptions.inc
@@ -33,6 +33,8 @@ OPTION(prefix_2, "metastr", _metastr, Separate, INVALID, INVALID, 0, 0, 0,
        "Set the meta command tag, default '.'", 0)
 OPTION(prefix_2, "nologo", _nologo, Flag, INVALID, INVALID, 0, 0, 0,
        "Do not show startup-banner", 0)
+OPTION(prefix_3, "noruntime", noruntime, Flag, INVALID, INVALID, 0, 0, 0,
+       "Disable runtime support (no null checking, no value printing)", 0)
 OPTION(prefix_3, "version", version, Flag, INVALID, INVALID, 0, 0, 0,
        "Print the compiler version", 0)
 OPTION(prefix_1, "v", v, Flag, INVALID, INVALID, 0, 0, 0,

--- a/include/cling/Interpreter/InvocationOptions.h
+++ b/include/cling/Interpreter/InvocationOptions.h
@@ -68,6 +68,7 @@ namespace cling {
     bool NoLogo;
     bool ShowVersion;
     bool Help;
+    bool NoRuntime;
     bool Verbose() const { return CompilerOpts.Verbose; }
 
     static void PrintHelp();

--- a/lib/Interpreter/IncrementalParser.cpp
+++ b/lib/Interpreter/IncrementalParser.cpp
@@ -275,9 +275,10 @@ namespace cling {
     // for ParseInternal()'s call EnterSourceFile() to make sense.
     while (!m_Parser->ParseTopLevelDecl()) {}
 
-    // If I belong to the parent Interpreter, only then do
-    // the #include <new>
-    if (!isChildInterpreter && m_CI->getLangOpts().CPlusPlus) {
+    // If I belong to the parent Interpreter, am using C++, and -noruntime
+    // wasn't given on command line, then #include <new> and check ABI
+    if (!isChildInterpreter && m_CI->getLangOpts().CPlusPlus &&
+        !m_Interpreter->getOptions().NoRuntime) {
       // <new> is needed by the ValuePrinter so it's a good thing to include it.
       // We need to include it to determine the version number of the standard
       // library implementation.
@@ -821,7 +822,7 @@ namespace cling {
     std::vector<ASTTPtr_t> ASTTransformers;
     ASTTransformers.emplace_back(new AutoSynthesizer(TheSema));
     ASTTransformers.emplace_back(new EvaluateTSynthesizer(TheSema));
-    if (hasCodeGenerator()) {
+    if (hasCodeGenerator() && !m_Interpreter->getOptions().NoRuntime) {
        // Don't protect against crashes if we cannot run anything.
        // cling might also be in a PCH-generation mode; don't inject our Sema pointer
        // into the PCH.
@@ -830,9 +831,12 @@ namespace cling {
 
     typedef std::unique_ptr<WrapperTransformer> WTPtr_t;
     std::vector<WTPtr_t> WrapperTransformers;
-    WrapperTransformers.emplace_back(new ValuePrinterSynthesizer(TheSema));
+    if (!m_Interpreter->getOptions().NoRuntime)
+      WrapperTransformers.emplace_back(new ValuePrinterSynthesizer(TheSema));
     WrapperTransformers.emplace_back(new DeclExtractor(TheSema));
-    WrapperTransformers.emplace_back(new ValueExtractionSynthesizer(TheSema, isChildInterpreter));
+    if (!m_Interpreter->getOptions().NoRuntime)
+      WrapperTransformers.emplace_back(new ValueExtractionSynthesizer(TheSema,
+                                                           isChildInterpreter));
     WrapperTransformers.emplace_back(new CheckEmptyTransactionTransformer(TheSema));
 
     m_Consumer->SetTransformers(std::move(ASTTransformers),

--- a/lib/Interpreter/Interpreter.cpp
+++ b/lib/Interpreter/Interpreter.cpp
@@ -235,7 +235,7 @@ namespace cling {
     }
 
     llvm::SmallVector<llvm::StringRef, 6> Syms;
-    Initialize(noRuntime, isInSyntaxOnlyMode(), Syms);
+    Initialize(noRuntime || m_Opts.NoRuntime, isInSyntaxOnlyMode(), Syms);
 
     // Commit the transactions, now that gCling is set up. It is needed for
     // static initialization in these transactions through local_cxa_atexit().

--- a/lib/Interpreter/InvocationOptions.cpp
+++ b/lib/Interpreter/InvocationOptions.cpp
@@ -65,6 +65,7 @@ namespace {
     Opts.NoLogo = Args.hasArg(OPT__nologo);
     Opts.ShowVersion = Args.hasArg(OPT_version);
     Opts.Help = Args.hasArg(OPT_help);
+    Opts.NoRuntime = Args.hasArg(OPT_noruntime);
     if (Arg* MetaStringArg = Args.getLastArg(OPT__metastr, OPT__metastr_EQ)) {
       Opts.MetaString = MetaStringArg->getValue();
       if (Opts.MetaString.empty()) {
@@ -137,7 +138,7 @@ void CompilerOptions::Parse(int argc, const char* const argv[],
 
 InvocationOptions::InvocationOptions(int argc, const char* const* argv) :
   MetaString("."), ErrorOut(false), NoLogo(false), ShowVersion(false),
-  Help(false) {
+  Help(false), NoRuntime(false) {
 
   ArrayRef<const char *> ArgStrings(argv, argv + argc);
   unsigned MissingArgIndex, MissingArgCount;

--- a/test/Driver/NoRuntime.C
+++ b/test/Driver/NoRuntime.C
@@ -1,0 +1,21 @@
+//------------------------------------------------------------------------------
+// CLING - the C++ LLVM-based InterpreterG :)
+//
+// This file is dual-licensed: you can choose to license it under the University
+// of Illinois Open Source License or the GNU Lesser General Public License. See
+// LICENSE.TXT for details.
+//------------------------------------------------------------------------------
+
+// RUN: cat %s | %cling -noruntime -Xclang -verify 2>&1 | FileCheck %s
+// Test noruntimeTest
+
+extern "C" int printf(const char*,...);
+int TEST = 9;
+TEST
+// CHECK-NOT: (int) 9
+
+printf("TEST: %d\n", TEST);
+// CHECK: TEST: 9
+
+// expected-no-diagnostics
+.q


### PR DESCRIPTION
This makes it tons easier to debug DeclUnload and discover what isn't being unloaded.

May be helpful for discussions relating to DeclUnloading as it allows on to run cling in a way where startup only...for example proving the test case in #95 is an accurate