### PR TITLE
Windows cleanup

### DIFF
--- a/test/Prompt/ValuePrinter/Strings.C
+++ b/test/Prompt/ValuePrinter/Strings.C
@@ -6,16 +6,18 @@
 // LICENSE.TXT for details.
 //------------------------------------------------------------------------------
 
-//RUN: cat %s | %cling -Xclang -verify 2>&1 | FileCheck %s
+// Windows wants -Wno-deprecated-declarations
+//RUN: cat %s | %cling -Wno-deprecated-declarations -Xclang -verify 2>&1 | FileCheck %s
 
 #include <stdlib.h>
 #ifdef _WIN32
  extern "C" int SetConsoleOutputCP(unsigned int);
+ extern "C" int strcmp(const char*, const char*);
 #endif
 
 static void setLang(const char* Lang) {
 #ifdef _WIN32
-  ::SetConsoleOutputCP(strcmp("en_US.UTF-8")==0 ? 65001 : 20127);
+  ::SetConsoleOutputCP(strcmp(Lang, "en_US.UTF-8")==0 ? 65001 : 20127);
 #else
   ::setenv("LANG", Lang, 1);
 #endif
@@ -120,6 +122,9 @@ std::u16string(u"UTF-16 " u"\x394" u"\x3a6" u"\x3a9")
 std::u32string(U"UTF-32 " U"\x262D" U"\x2615" U"\x265F")
 // CHECK-NEXT: (std::u32string) U"UTF-32 ☭☕♟"
 
+std::u32string(U"UTF-32 " U"\u2616\u2615\u2614")
+// CHECK-NEXT: (std::u32string) U"UTF-32 ☖☕☔"
+
 std::wstring(L"wide")
 // CHECK-NEXT: (std::wstring) L"wide"
 
@@ -156,6 +161,9 @@ u"UTF-16 " u"\x394" u"\x3a6" u"\x3a9"
 
 U"UTF-32\x262D\x2615\x265F"
 // CHECK-NEXT: (const char32_t [10]) U"UTF-32\u262d\u2615\u265f"
+
+U"UTF-32\x2616\x2615\x2614"
+// CHECK-NEXT: (const char32_t [10]) U"UTF-32\u2616\u2615\u2614"
 
 "\u20ac"
 // CHECk-NEXT: (const char [4]) "\xe2\x82\xac"

--- a/test/Prompt/initorder.C
+++ b/test/Prompt/initorder.C
@@ -26,8 +26,8 @@ public:
    int get() { return *I; }
    ~RAII() { delete I; printf("~RAII%d\n", InstanceCount--); }
 private:
-   RAII(RAII&) {throw;};
-   RAII& operator=(RAII) {throw;}
+   RAII(RAII&);
+   RAII& operator=(RAII);
    int* I;
    static int InstanceCount; // will notice object copy
 };

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -39,10 +39,62 @@ set_target_properties(cling
   PROPERTIES ENABLE_EXPORTS 1)
 
 if(MSVC)
-  set_target_properties(cling
-    PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
-  set_property(TARGET cling APPEND_STRING PROPERTY LINK_FLAGS
-    " /EXPORT:??_7type_info@@6B@ /EXPORT:?__type_info_root_node@@3U__type_info_node@@A /EXPORT:_Init_thread_abort /EXPORT:_Init_thread_epoch /EXPORT:_Init_thread_footer /EXPORT:_Init_thread_header /EXPORT:_tls_index /EXPORT:?getAsString@QualType@clang@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBVType@2@VQualifiers@2@@Z /EXPORT:?print@Decl@clang@@QEBAXAEAVraw_ostream@llvm@@I_N@Z /EXPORT:??6raw_ostream@llvm@@QEAAAEAV01@PEBX@Z /EXPORT:?getQualifiedNameAsString@NamedDecl@clang@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ /EXPORT:?insert_imp_big@SmallPtrSetImplBase@llvm@@AEAA?AU?$pair@PEBQEBX_N@std@@PEBX@Z /EXPORT:?getAsStringInternal@QualType@clang@@SAXPEBVType@2@VQualifiers@2@AEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUPrintingPolicy@2@@Z /EXPORT:?_Facet_Register@std@@YAXPEAV_Facet_base@1@@Z /EXPORT:?decls_begin@DeclContext@clang@@QEBA?AVdecl_iterator@12@XZ /EXPORT:?nothrow@std@@3Unothrow_t@1@B /EXPORT:?field_begin@RecordDecl@clang@@QEBA?AV?$specific_decl_iterator@VFieldDecl@clang@@@DeclContext@2@XZ /EXPORT:?errs@llvm@@YAAEAVraw_ostream@1@XZ /EXPORT:?grow_pod@SmallVectorBase@llvm@@IEAAXPEAX_K1@Z /EXPORT:?write@raw_ostream@llvm@@QEAAAEAV12@E@Z /EXPORT:?kEmptyCollection@valuePrinterInternal@cling@@3QEBDEB /EXPORT:?write@raw_ostream@llvm@@QEAAAEAV12@PEBD_K@Z /EXPORT:?castFromDeclContext@Decl@clang@@SAPEAV12@PEBVDeclContext@2@@Z /EXPORT:??1raw_ostream@llvm@@UEAA@XZ /EXPORT:?dump@Decl@clang@@QEBAXAEAVraw_ostream@llvm@@@Z /EXPORT:??1raw_string_ostream@llvm@@UEAA@XZ /EXPORT:?flush_nonempty@raw_ostream@llvm@@AEAAXXZ /EXPORT:??$dyn_cast@VValueDecl@clang@@$$CBVDecl@2@@llvm@@YAPEBVValueDecl@clang@@PEBVDecl@2@@Z /EXPORT:?getASTContext@Decl@clang@@QEBAAEAVASTContext@2@XZ /EXPORT:?handle@raw_ostream@llvm@@EEAAXXZ /EXPORT:?preferred_buffer_size@raw_ostream@llvm@@MEBA_KXZ /EXPORT:?write_impl@raw_string_ostream@llvm@@EEAAXPEBD_K@Z")
+  set_target_properties(cling PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+
+  # Internal string
+  set(cling_exports ?kEmptyCollection@valuePrinterInternal@cling@@3QEBDEB)
+
+  # RTTI/C++ symbols
+  set(cling_exports ${cling_exports} ??_7type_info@@6B@
+    ?__type_info_root_node@@3U__type_info_node@@A
+    ?nothrow@std@@3Unothrow_t@1@B
+    ?_Facet_Register@std@@YAXPEAV_Facet_base@1@@Z
+  )
+
+  # Compiler added symbols for static variables. NOT for VStudio < 2015
+  set(cling_exports ${cling_exports} _Init_thread_abort _Init_thread_epoch
+    _Init_thread_footer _Init_thread_header _tls_index
+  )
+
+  # Most (if not all) of these MSVC decided are inlines that aren't exported
+  set(cling_exports ${cling_exports} ?print@Decl@clang@@QEBAXAEAVraw_ostream@llvm@@I_N@Z
+    ?getAsString@QualType@clang@@SA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@PEBVType@2@VQualifiers@2@@Z
+    ??6raw_ostream@llvm@@QEAAAEAV01@PEBX@Z
+    ?getQualifiedNameAsString@NamedDecl@clang@@QEBA?AV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@XZ
+    ?insert_imp_big@SmallPtrSetImplBase@llvm@@AEAA?AU?$pair@PEBQEBX_N@std@@PEBX@Z
+    ?getAsStringInternal@QualType@clang@@SAXPEBVType@2@VQualifiers@2@AEAV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@AEBUPrintingPolicy@2@@Z
+    ?decls_begin@DeclContext@clang@@QEBA?AVdecl_iterator@12@XZ
+    ?field_begin@RecordDecl@clang@@QEBA?AV?$specific_decl_iterator@VFieldDecl@clang@@@DeclContext@2@XZ
+    ?errs@llvm@@YAAEAVraw_ostream@1@XZ
+    ?grow_pod@SmallVectorBase@llvm@@IEAAXPEAX_K1@Z
+    ?write@raw_ostream@llvm@@QEAAAEAV12@E@Z
+    ?write@raw_ostream@llvm@@QEAAAEAV12@PEBD_K@Z
+    ?castFromDeclContext@Decl@clang@@SAPEAV12@PEBVDeclContext@2@@Z
+    ??1raw_ostream@llvm@@UEAA@XZ
+    ?dump@Decl@clang@@QEBAXAEAVraw_ostream@llvm@@@Z
+    ??1raw_string_ostream@llvm@@UEAA@XZ
+    ?flush_nonempty@raw_ostream@llvm@@AEAAXXZ
+    ?getASTContext@Decl@clang@@QEBAAEAVASTContext@2@XZ
+    ?handle@raw_ostream@llvm@@EEAAXXZ
+    ?preferred_buffer_size@raw_ostream@llvm@@MEBA_KXZ
+    ?write_impl@raw_string_ostream@llvm@@EEAAXPEBD_K@Z
+    ?castToDeclContext@Decl@clang@@SAPEAVDeclContext@2@PEBV12@@Z
+    ?classof@DeclContext@clang@@SA_NPEBVDecl@2@@Z
+  )
+
+  if (CMAKE_BUILD_TYPE MATCHES Debug)
+    set(cling_exports ${cling_exports}
+      ??$dyn_cast@VValueDecl@clang@@$$CBVDecl@2@@llvm@@YAPEBVValueDecl@clang@@PEBVDecl@2@@Z
+    )
+  endif()
+
+  # List to '/EXPORT:sym0 /EXPORT:sym1 /EXPORT:sym2 ...'
+  foreach(sym ${cling_exports})
+    set(cling_link_str "${cling_link_str} /EXPORT:${sym}")
+  endforeach(sym ${cling_exports})
+
+  set_property(TARGET cling APPEND_STRING PROPERTY LINK_FLAGS ${cling_link_str})
+
 endif(MSVC)
 
 target_link_libraries(cling


### PR DESCRIPTION
Cleanup CMake exports.
Remove horrible string hack, one of the new exports seems to fix the issue.
Remove exception specification from one test.