### PR TITLE
Fix EscapeSequence::encode returning a StringRef pointing to stack memory

### DIFF
--- a/include/cling/Utils/UTF8.h
+++ b/include/cling/Utils/UTF8.h
@@ -10,8 +10,9 @@
 #ifndef CLING_UTILS_UTF8_H
 #define CLING_UTILS_UTF8_H
 
-#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
 #include <locale>
+#include <string>
 
 namespace cling {
 
@@ -64,6 +65,7 @@ namespace cling {
 
       public:
         EscapeSequence();
+
         ///\brief Encode the bytes from Str into a representation capable of
         /// being printed in the current locale without data loss.
         /// When Str begins with any of the C++ unicode string literal
@@ -71,8 +73,16 @@ namespace cling {
         ///
         /// \param [in] Str - Start of bytes to convert
         /// \param [in] N - Number of bytes to convert
+        /// \param [in] Output - Ouput stream to write to
         ///
-        llvm::StringRef encode(const char* const Str, size_t N);
+        /// \return 'Output' to allow: EscapeSequence().encode(...) << "";
+        ///
+        llvm::raw_ostream& encode(const char* const Str, size_t N,
+                                  llvm::raw_ostream& Output);
+
+        ///\brief Overload for above returning a std::string.
+        ///
+        std::string encode(const char* const Str, size_t N);
       };
     }
   }

--- a/lib/Interpreter/Value.cpp
+++ b/lib/Interpreter/Value.cpp
@@ -250,8 +250,8 @@ namespace cling {
         case '\"':
           if (N > 2 && Data[N-1] == '\"') {
             // Drop the terminating " so Utf-8 errors can be detected ("\xeA")
-            Out << Type << ' '
-                << utils::utf8::EscapeSequence().encode(Data, N-1) << "\"\n";
+            Out << Type << ' ';
+            utils::utf8::EscapeSequence().encode(Data, N-1, Out) << "\"\n";
             return;
           }
         default:


### PR DESCRIPTION
Pretty bad one...surprised no compiler or test has caught it yet.